### PR TITLE
Fix: Return Err if socket parent dir was not created

### DIFF
--- a/src/platform/linux/uapi.rs
+++ b/src/platform/linux/uapi.rs
@@ -14,7 +14,7 @@ impl PlatformUAPI for LinuxUAPI {
 
     fn bind(name: &str) -> Result<UnixListener, io::Error> {
         let socket_path = format!("{}{}.sock", SOCK_DIR, name);
-        let _ = fs::create_dir_all(SOCK_DIR);
+        fs::create_dir_all(SOCK_DIR)?;
         let _ = fs::remove_file(&socket_path);
         UnixListener::bind(socket_path)
     }


### PR DESCRIPTION
Fix unclear error reporting when parent directory for socket file does not exist, and the program is not able to create it for any reason. In this case the old behavior was to silently ignore the error, and later fail with a different message. This way the actual issue with creating the directory was not displayed to the user.