### PR TITLE
Set log level to error for netns error messages

### DIFF
--- a/src/configuration/uapi/mod.rs
+++ b/src/configuration/uapi/mod.rs
@@ -67,7 +67,11 @@ pub fn handle<S: Read + Write, C: Configuration>(stream: &mut S, config: &C) {
 
     // process operation
     let res = operation(stream, config);
-    log::debug!("UAPI, Result of operation: {:?}", res);
+
+    match res {
+        Ok(_) => log::debug!("UAPI, Result of operation: OK"),
+        Err(ref e) => log::error!("UAPI, Result of operation: {}", e),
+    }
 
     // return errno
     let _ = stream.write("errno=".as_ref());

--- a/src/wireguard/workers.rs
+++ b/src/wireguard/workers.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use byteorder::{ByteOrder, LittleEndian};
 use crossbeam_channel::Receiver;
-use log::debug;
+use log::{debug, error};
 use rand::rngs::OsRng;
 use x25519_dalek::PublicKey;
 
@@ -65,7 +65,7 @@ pub fn tun_worker<T: Tun, B: UDP>(wg: &WireGuard<T, B>, reader: T::Reader) {
         let payload = match reader.read(&mut msg[..], SIZE_MESSAGE_PREFIX) {
             Ok(payload) => payload,
             Err(e) => {
-                debug!("TUN worker, failed to read from tun device: {}", e);
+                error!("TUN worker, failed to read from tun device: {}", e);
                 break;
             }
         };


### PR DESCRIPTION
When running netns.sh, some error messages have been displayed with debug log level, which have now been changed to error level, making them easier to find in console output.