### PR TITLE
Separate PeerInner and Timers code

### DIFF
--- a/src/wireguard/peer.rs
+++ b/src/wireguard/peer.rs
@@ -139,7 +139,8 @@ impl<T: Tun, B: UDP> PeerInner<T, B> {
      */
     pub fn timers_handshake_complete(&self) {
         log::trace!("timers_handshake_complete");
-        if self.timers().stop_retransmit_handshake_timer() {
+        let timers_update_result = self.timers().stop_retransmit_handshake_timer();
+        if timers_update_result.is_some() {
             *self.walltime_last_handshake.lock() = Some(SystemTime::now());
         }
     }

--- a/src/wireguard/peer.rs
+++ b/src/wireguard/peer.rs
@@ -3,12 +3,17 @@ use super::timers::Timers;
 use super::tun::Tun;
 use super::udp::UDP;
 
-use super::constants::REKEY_TIMEOUT;
+use super::constants::*;
+use super::router::{Callbacks, message_data_len};
+use super::types::KeyPair;
 use super::wireguard::WireGuard;
 use super::workers::HandshakeJob;
 
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
 use std::time::{Instant, SystemTime};
 
 use spin::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -81,6 +86,188 @@ impl<T: Tun, B: UDP> PeerInner<T, B> {
     #[inline(always)]
     pub fn timers_mut(&'_ self) -> RwLockWriteGuard<'_, Timers> {
         self.timers.write()
+    }
+
+    pub fn get_keepalive_interval(&self) -> u64 {
+        self.timers().get_keepalive_interval()
+    }
+
+    pub fn stop_timers(&self) {
+        self.timers_mut().disable();
+    }
+
+    pub fn start_timers(&self) {
+        self.timers_mut().enable();
+    }
+
+    /* should be called after an authenticated data packet is sent */
+    pub fn timers_data_sent(&self) {
+        self.timers().start_new_handshake_timer();
+    }
+
+    /* should be called after an authenticated data packet is received */
+    pub fn timers_data_received(&self) {
+        self.timers().queue_another_keepalive();
+    }
+
+    /* Should be called after any type of authenticated packet is sent, whether:
+     * - keepalive
+     * - data
+     * - handshake
+     */
+    pub fn timers_any_authenticated_packet_sent(&self) {
+        log::trace!("timers_any_authenticated_packet_sent");
+        self.timers().stop_send_keepalive_timer();
+    }
+
+    /* Should be called after any type of authenticated packet is received, whether:
+     * - keepalive
+     * - data
+     * - handshake
+     */
+    pub fn timers_any_authenticated_packet_received(&self) {
+        log::trace!("timers_any_authenticated_packet_received");
+        self.timers().stop_new_handshake_timer();
+    }
+
+    /* Should be called after a handshake initiation message is sent. */
+    pub fn timers_handshake_initiated(&self) {
+        log::trace!("timers_handshake_initiated");
+        self.timers().restart_retransmit_handshake_timer();
+    }
+
+    /* Should be called after a handshake response message is received and processed
+     * or when getting key confirmation via the first data message.
+     */
+    pub fn timers_handshake_complete(&self) {
+        log::trace!("timers_handshake_complete");
+        if self.timers().stop_retransmit_handshake_timer() {
+            *self.walltime_last_handshake.lock() = Some(SystemTime::now());
+        }
+    }
+
+    /* Should be called after an ephemeral key is created, which is before sending a
+     * handshake response or after receiving a handshake response.
+     */
+    pub fn timers_session_derived(&self) {
+        log::trace!("timers_session_derived");
+        self.timers().restart_zero_key_material_timer();
+    }
+
+    /* Should be called before a packet with authentication, whether
+     * keepalive, data, or handshake is sent, or after one is received.
+     */
+    pub fn timers_any_authenticated_packet_traversal(&self) {
+        log::trace!("timers_any_authenticated_packet_traversal");
+        self.timers().push_persistent_keepalive_into_future();
+    }
+
+    /* Called after a handshake worker sends a handshake initiation to the peer
+     */
+    pub fn sent_handshake_initiation(&self) {
+        *self.last_handshake_sent.lock() = Instant::now();
+        self.timers_handshake_initiated();
+        self.timers_any_authenticated_packet_traversal();
+        self.timers_any_authenticated_packet_sent();
+    }
+
+    pub fn sent_handshake_response(&self) {
+        *self.last_handshake_sent.lock() = Instant::now();
+        self.timers_any_authenticated_packet_traversal();
+        self.timers_any_authenticated_packet_sent();
+    }
+
+    pub fn set_persistent_keepalive_interval(&self, secs: u64) {
+        self.timers_mut().set_persistent_keepalive_interval(secs);
+    }
+
+    pub fn packet_send_queued_handshake_initiation(&self, is_retry: bool) {
+        if !is_retry {
+            self.timers().reset_handshake_attempts();
+        }
+        self.packet_send_handshake_initiation();
+    }
+}
+
+impl<T: Tun, B: UDP> Callbacks for PeerInner<T, B> {
+    type Opaque = Self;
+
+    /* Called after the router encrypts a transport message destined for the peer.
+     * This method is called, even if the encrypted payload is empty (keepalive)
+     */
+    #[inline(always)]
+    fn send(peer: &Self::Opaque, size: usize, sent: bool, keypair: &Arc<KeyPair>, counter: u64) {
+        log::trace!("{} : EVENT(send)", peer);
+
+        // update timers and stats
+
+        peer.timers_any_authenticated_packet_traversal();
+        peer.timers_any_authenticated_packet_sent();
+        peer.tx_bytes.fetch_add(size as u64, Ordering::Relaxed);
+        if size > message_data_len(0) && sent {
+            peer.timers_data_sent();
+        }
+
+        // keep_key_fresh
+
+        fn keep_key_fresh(keypair: &Arc<KeyPair>, counter: u64) -> bool {
+            counter > REKEY_AFTER_MESSAGES
+                || (keypair.initiator && Instant::now() - keypair.birth > REKEY_AFTER_TIME)
+        }
+
+        if keep_key_fresh(keypair, counter) {
+            peer.packet_send_queued_handshake_initiation(false);
+        }
+    }
+
+    /* Called after the router successfully decrypts a transport message from a peer.
+     * This method is called, even if the decrypted packet is:
+     *
+     * - A keepalive
+     * - A malformed IP packet
+     * - Fails to cryptkey route
+     */
+    #[inline(always)]
+    fn recv(peer: &Self::Opaque, size: usize, sent: bool, keypair: &Arc<KeyPair>) {
+        log::trace!("{} : EVENT(recv)", peer);
+
+        // update timers and stats
+
+        peer.timers_any_authenticated_packet_traversal();
+        peer.timers_any_authenticated_packet_received();
+        peer.rx_bytes.fetch_add(size as u64, Ordering::Relaxed);
+        if size > 0 && sent {
+            peer.timers_data_received();
+        }
+
+        // keep_key_fresh
+
+        #[inline(always)]
+        fn keep_key_fresh(keypair: &Arc<KeyPair>) -> bool {
+            Instant::now() - keypair.birth > REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
+        }
+
+        if keep_key_fresh(keypair) && peer.timers().register_lastminute_handshake_sent() {
+            peer.packet_send_queued_handshake_initiation(false);
+        }
+    }
+
+    /* Called every time the router detects that a key is required,
+     * but no valid key-material is available for the particular peer.
+     *
+     * The message is called continuously
+     * (e.g. for every packet that must be encrypted, until a key becomes available)
+     */
+    #[inline(always)]
+    fn need_key(peer: &Self::Opaque) {
+        log::trace!("{} : EVENT(need_key)", peer);
+        peer.packet_send_queued_handshake_initiation(false);
+    }
+
+    #[inline(always)]
+    fn key_confirmed(peer: &Self::Opaque) {
+        log::trace!("{} : EVENT(key_confirmed)", peer);
+        peer.timers_handshake_complete();
     }
 }
 

--- a/src/wireguard/peer.rs
+++ b/src/wireguard/peer.rs
@@ -1,14 +1,3 @@
-use super::timers::Timers;
-
-use super::tun::Tun;
-use super::udp::UDP;
-
-use super::constants::*;
-use super::router::{Callbacks, message_data_len};
-use super::types::KeyPair;
-use super::wireguard::WireGuard;
-use super::workers::HandshakeJob;
-
 use std::fmt;
 use std::sync::{
     Arc,
@@ -19,6 +8,15 @@ use std::time::{Instant, SystemTime};
 use spin::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use x25519_dalek::PublicKey;
+
+use super::constants::*;
+use super::router::{Callbacks, message_data_len};
+use super::timers::Timers;
+use super::tun::Tun;
+use super::types::KeyPair;
+use super::udp::UDP;
+use super::wireguard::WireGuard;
+use super::workers::HandshakeJob;
 
 pub struct PeerInner<T: Tun, B: UDP> {
     // internal id (for logging)

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -29,7 +29,7 @@ pub struct Timers {
 
 impl Timers {
     #[inline(always)]
-    fn need_another_keepalive(&self) -> bool {
+    fn needs_another_keepalive(&self) -> bool {
         self.need_another_keepalive.swap(false, Ordering::SeqCst)
     }
 
@@ -108,7 +108,7 @@ impl Timers {
 
                     // send keepalive and schedule next keepalive
                     peer.send_keepalive();
-                    if timers.need_another_keepalive() {
+                    if timers.needs_another_keepalive() {
                         timers.send_keepalive.start(KEEPALIVE_TIMEOUT);
                     }
                 })

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -27,6 +27,8 @@ pub struct Timers {
     new_handshake: Timer,
 }
 
+/// Find peer based on public key and assign to variable, or call return from parent scope if
+/// not found
 macro_rules! fetch_peer {
     ( $wireguard_device:expr_2021, $public_key_of_peer:expr_2021, $peer:ident) => {
         let peers = $wireguard_device.peers.read();
@@ -39,6 +41,8 @@ macro_rules! fetch_peer {
     };
 }
 
+/// Find peer and timers based on public key and assign them to variables, or call return from
+/// parent scope if peer not found or timers not enabled
 macro_rules! fetch_peer_and_timers {
     ( $wireguard_device:expr_2021, $public_key_of_peer:expr_2021, $peer:ident, $timers:ident) => {
         fetch_peer!($wireguard_device, $public_key_of_peer, $peer);

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -277,18 +277,18 @@ impl Timers {
         }
     }
 
-    /// Return true if timers are enabled, false otherwise
-    pub fn stop_retransmit_handshake_timer(&self) -> bool {
+    /// Return Some(()) if timers are enabled, None otherwise
+    pub fn stop_retransmit_handshake_timer(&self) -> Option<()> {
         if self.enabled {
             self.retransmit_handshake.stop();
             self.handshake_attempts.store(0, Ordering::SeqCst);
             self.sent_lastminute_handshake
                 .store(false, Ordering::SeqCst);
 
-            return true;
+            return Some(());
         }
 
-        false
+        return None;
     }
 
     pub fn restart_zero_key_material_timer(&self) {

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::Duration;
 
 use log::debug;
 
@@ -9,10 +8,7 @@ use x25519_dalek::PublicKey;
 
 use super::WireGuard;
 use super::constants::*;
-use super::peer::PeerInner;
-use super::router::{Callbacks, message_data_len};
 use super::tun::Tun;
-use super::types::KeyPair;
 use super::udp::UDP;
 
 pub struct Timers {
@@ -36,201 +32,7 @@ impl Timers {
     fn need_another_keepalive(&self) -> bool {
         self.need_another_keepalive.swap(false, Ordering::SeqCst)
     }
-}
 
-impl<T: Tun, B: UDP> PeerInner<T, B> {
-    pub fn get_keepalive_interval(&self) -> u64 {
-        self.timers().keepalive_interval
-    }
-
-    pub fn stop_timers(&self) {
-        // take a write lock preventing simultaneous timer events or "start_timers" call
-        let mut timers = self.timers_mut();
-
-        // set flag to prevent future timer events
-        if !timers.enabled {
-            return;
-        }
-        timers.enabled = false;
-
-        // stop all pending timers
-        timers.retransmit_handshake.stop();
-        timers.send_keepalive.stop();
-        timers.send_persistent_keepalive.stop();
-        timers.zero_key_material.stop();
-        timers.new_handshake.stop();
-
-        // reset all timer state
-        timers.handshake_attempts.store(0, Ordering::SeqCst);
-        timers
-            .sent_lastminute_handshake
-            .store(false, Ordering::SeqCst);
-        timers.need_another_keepalive.store(false, Ordering::SeqCst);
-    }
-
-    pub fn start_timers(&self) {
-        // take a write lock preventing simultaneous "stop_timers" call
-        let mut timers = self.timers_mut();
-
-        // set flag to reenable timer events
-        if timers.enabled {
-            return;
-        }
-        timers.enabled = true;
-
-        // start send_persistent_keepalive
-        if timers.keepalive_interval > 0 {
-            timers
-                .send_persistent_keepalive
-                .start(Duration::from_secs(0));
-        }
-    }
-
-    /* should be called after an authenticated data packet is sent */
-    pub fn timers_data_sent(&self) {
-        let timers = self.timers();
-        if timers.enabled {
-            timers
-                .new_handshake
-                .start(KEEPALIVE_TIMEOUT + REKEY_TIMEOUT);
-        }
-    }
-
-    /* should be called after an authenticated data packet is received */
-    pub fn timers_data_received(&self) {
-        let timers = self.timers();
-        if timers.enabled && !timers.send_keepalive.start(KEEPALIVE_TIMEOUT) {
-            timers.need_another_keepalive.store(true, Ordering::SeqCst)
-        }
-    }
-
-    /* Should be called after any type of authenticated packet is sent, whether:
-     * - keepalive
-     * - data
-     * - handshake
-     */
-    pub fn timers_any_authenticated_packet_sent(&self) {
-        log::trace!("timers_any_authenticated_packet_sent");
-        let timers = self.timers();
-        if timers.enabled {
-            timers.send_keepalive.stop()
-        }
-    }
-
-    /* Should be called after any type of authenticated packet is received, whether:
-     * - keepalive
-     * - data
-     * - handshake
-     */
-    pub fn timers_any_authenticated_packet_received(&self) {
-        log::trace!("timers_any_authenticated_packet_received");
-        let timers = self.timers();
-        if timers.enabled {
-            timers.new_handshake.stop();
-        }
-    }
-
-    /* Should be called after a handshake initiation message is sent. */
-    pub fn timers_handshake_initiated(&self) {
-        log::trace!("timers_handshake_initiated");
-        let timers = self.timers();
-        if timers.enabled {
-            timers.send_keepalive.stop();
-            timers.retransmit_handshake.reset(REKEY_TIMEOUT);
-        }
-    }
-
-    /* Should be called after a handshake response message is received and processed
-     * or when getting key confirmation via the first data message.
-     */
-    pub fn timers_handshake_complete(&self) {
-        log::trace!("timers_handshake_complete");
-        let timers = self.timers();
-        if timers.enabled {
-            timers.retransmit_handshake.stop();
-            timers.handshake_attempts.store(0, Ordering::SeqCst);
-            timers
-                .sent_lastminute_handshake
-                .store(false, Ordering::SeqCst);
-            *self.walltime_last_handshake.lock() = Some(SystemTime::now());
-        }
-    }
-
-    /* Should be called after an ephemeral key is created, which is before sending a
-     * handshake response or after receiving a handshake response.
-     */
-    pub fn timers_session_derived(&self) {
-        log::trace!("timers_session_derived");
-        let timers = self.timers();
-        if timers.enabled {
-            timers.zero_key_material.reset(REJECT_AFTER_TIME * 3);
-        }
-    }
-
-    /* Should be called before a packet with authentication, whether
-     * keepalive, data, or handshake is sent, or after one is received.
-     */
-    pub fn timers_any_authenticated_packet_traversal(&self) {
-        log::trace!("timers_any_authenticated_packet_traversal");
-        let timers = self.timers();
-        if timers.enabled && timers.keepalive_interval > 0 {
-            // push persistent_keepalive into the future
-            timers
-                .send_persistent_keepalive
-                .reset(Duration::from_secs(timers.keepalive_interval));
-        }
-    }
-
-    fn timers_set_retransmit_handshake(&self) {
-        log::trace!("timers_set_retransmit_handshake");
-        let timers = self.timers();
-        if timers.enabled {
-            timers.retransmit_handshake.reset(REKEY_TIMEOUT);
-        }
-    }
-
-    /* Called after a handshake worker sends a handshake initiation to the peer
-     */
-    pub fn sent_handshake_initiation(&self) {
-        *self.last_handshake_sent.lock() = Instant::now();
-        self.timers_handshake_initiated();
-        self.timers_set_retransmit_handshake();
-        self.timers_any_authenticated_packet_traversal();
-        self.timers_any_authenticated_packet_sent();
-    }
-
-    pub fn sent_handshake_response(&self) {
-        *self.last_handshake_sent.lock() = Instant::now();
-        self.timers_any_authenticated_packet_traversal();
-        self.timers_any_authenticated_packet_sent();
-    }
-
-    pub fn set_persistent_keepalive_interval(&self, secs: u64) {
-        let mut timers = self.timers_mut();
-
-        // update the stored keepalive_interval
-        timers.keepalive_interval = secs;
-
-        // stop the keepalive timer with the old interval
-        timers.send_persistent_keepalive.stop();
-
-        // cause immediate expiry of persistent_keepalive timer
-        if secs > 0 && timers.enabled {
-            timers
-                .send_persistent_keepalive
-                .reset(Duration::from_secs(0));
-        }
-    }
-
-    fn packet_send_queued_handshake_initiation(&self, is_retry: bool) {
-        if !is_retry {
-            self.timers().handshake_attempts.store(0, Ordering::SeqCst);
-        }
-        self.packet_send_handshake_initiation();
-    }
-}
-
-impl Timers {
     pub fn new<T: Tun, B: UDP>(
         wg: WireGuard<T, B>, // WireGuard device
         pk: PublicKey,       // public key of peer
@@ -360,91 +162,120 @@ impl Timers {
             },
         }
     }
-}
 
-impl<T: Tun, B: UDP> Callbacks for PeerInner<T, B> {
-    type Opaque = Self;
+    pub fn get_keepalive_interval(&self) -> u64 {
+        self.keepalive_interval
+    }
 
-    /* Called after the router encrypts a transport message destined for the peer.
-     * This method is called, even if the encrypted payload is empty (keepalive)
-     */
-    #[inline(always)]
-    fn send(peer: &Self::Opaque, size: usize, sent: bool, keypair: &Arc<KeyPair>, counter: u64) {
-        log::trace!("{} : EVENT(send)", peer);
-
-        // update timers and stats
-
-        peer.timers_any_authenticated_packet_traversal();
-        peer.timers_any_authenticated_packet_sent();
-        peer.tx_bytes.fetch_add(size as u64, Ordering::Relaxed);
-        if size > message_data_len(0) && sent {
-            peer.timers_data_sent();
+    pub fn enable(&mut self) {
+        // set flag to reenable timer events
+        if self.enabled {
+            return;
         }
+        self.enabled = true;
 
-        // keep_key_fresh
-
-        fn keep_key_fresh(keypair: &Arc<KeyPair>, counter: u64) -> bool {
-            counter > REKEY_AFTER_MESSAGES
-                || (keypair.initiator && Instant::now() - keypair.birth > REKEY_AFTER_TIME)
-        }
-
-        if keep_key_fresh(keypair, counter) {
-            peer.packet_send_queued_handshake_initiation(false);
+        // start send_persistent_keepalive
+        if self.keepalive_interval > 0 {
+            self.send_persistent_keepalive.start(Duration::from_secs(0));
         }
     }
 
-    /* Called after the router successfully decrypts a transport message from a peer.
-     * This method is called, even if the decrypted packet is:
-     *
-     * - A keepalive
-     * - A malformed IP packet
-     * - Fails to cryptkey route
-     */
-    #[inline(always)]
-    fn recv(peer: &Self::Opaque, size: usize, sent: bool, keypair: &Arc<KeyPair>) {
-        log::trace!("{} : EVENT(recv)", peer);
-
-        // update timers and stats
-
-        peer.timers_any_authenticated_packet_traversal();
-        peer.timers_any_authenticated_packet_received();
-        peer.rx_bytes.fetch_add(size as u64, Ordering::Relaxed);
-        if size > 0 && sent {
-            peer.timers_data_received();
+    pub fn disable(&mut self) {
+        // set flag to prevent future timer events
+        if !self.enabled {
+            return;
         }
+        self.enabled = false;
 
-        // keep_key_fresh
+        // stop all pending timers
+        self.retransmit_handshake.stop();
+        self.send_keepalive.stop();
+        self.send_persistent_keepalive.stop();
+        self.zero_key_material.stop();
+        self.new_handshake.stop();
 
-        #[inline(always)]
-        fn keep_key_fresh(keypair: &Arc<KeyPair>) -> bool {
-            Instant::now() - keypair.birth > REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
-        }
+        // reset all timer state
+        self.handshake_attempts.store(0, Ordering::SeqCst);
+        self.sent_lastminute_handshake
+            .store(false, Ordering::SeqCst);
+        self.need_another_keepalive.store(false, Ordering::SeqCst);
+    }
 
-        if keep_key_fresh(keypair)
-            && !peer
-                .timers()
-                .sent_lastminute_handshake
-                .swap(true, Ordering::Acquire)
-        {
-            peer.packet_send_queued_handshake_initiation(false);
+    pub fn start_new_handshake_timer(&self) {
+        if self.enabled {
+            self.new_handshake.start(KEEPALIVE_TIMEOUT + REKEY_TIMEOUT);
         }
     }
 
-    /* Called every time the router detects that a key is required,
-     * but no valid key-material is available for the particular peer.
-     *
-     * The message is called continuously
-     * (e.g. for every packet that must be encrypted, until a key becomes available)
-     */
-    #[inline(always)]
-    fn need_key(peer: &Self::Opaque) {
-        log::trace!("{} : EVENT(need_key)", peer);
-        peer.packet_send_queued_handshake_initiation(false);
+    pub fn queue_another_keepalive(&self) {
+        if self.enabled && !self.send_keepalive.start(KEEPALIVE_TIMEOUT) {
+            self.need_another_keepalive.store(true, Ordering::SeqCst)
+        }
     }
 
-    #[inline(always)]
-    fn key_confirmed(peer: &Self::Opaque) {
-        log::trace!("{} : EVENT(key_confirmed)", peer);
-        peer.timers_handshake_complete();
+    pub fn stop_send_keepalive_timer(&self) {
+        if self.enabled {
+            self.send_keepalive.stop()
+        }
+    }
+
+    pub fn stop_new_handshake_timer(&self) {
+        if self.enabled {
+            self.new_handshake.stop();
+        }
+    }
+
+    pub fn restart_retransmit_handshake_timer(&self) {
+        if self.enabled {
+            self.send_keepalive.stop();
+            self.retransmit_handshake.reset(REKEY_TIMEOUT);
+        }
+    }
+
+    pub fn stop_retransmit_handshake_timer(&self) -> bool {
+        if self.enabled {
+            self.retransmit_handshake.stop();
+            self.handshake_attempts.store(0, Ordering::SeqCst);
+            self.sent_lastminute_handshake
+                .store(false, Ordering::SeqCst);
+
+            return true;
+        }
+
+        false
+    }
+
+    pub fn restart_zero_key_material_timer(&self) {
+        if self.enabled {
+            self.zero_key_material.reset(REJECT_AFTER_TIME * 3);
+        }
+    }
+
+    pub fn push_persistent_keepalive_into_future(&self) {
+        if self.enabled && self.keepalive_interval > 0 {
+            self.send_persistent_keepalive
+                .reset(Duration::from_secs(self.keepalive_interval));
+        }
+    }
+
+    pub fn set_persistent_keepalive_interval(&mut self, secs: u64) {
+        // update the stored keepalive_interval
+        self.keepalive_interval = secs;
+
+        // stop the keepalive timer with the old interval
+        self.send_persistent_keepalive.stop();
+
+        // cause immediate expiry of persistent_keepalive timer
+        if secs > 0 && self.enabled {
+            self.send_persistent_keepalive.reset(Duration::from_secs(0));
+        }
+    }
+
+    pub fn reset_handshake_attempts(&self) {
+        self.handshake_attempts.store(0, Ordering::SeqCst);
+    }
+
+    pub fn register_lastminute_handshake_sent(&self) -> bool {
+        !self.sent_lastminute_handshake.swap(true, Ordering::Acquire)
     }
 }

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use log::debug;
 
-use hjul::Timer;
+use hjul::{Runner, Timer};
 use x25519_dalek::PublicKey;
 
 use super::WireGuard;
@@ -27,6 +27,27 @@ pub struct Timers {
     new_handshake: Timer,
 }
 
+macro_rules! fetch_peer {
+    ( $wireguard_device:expr_2021, $public_key_of_peer:expr_2021, $peer:ident) => {
+        let peers = $wireguard_device.peers.read();
+        let $peer = match peers.get(&$public_key_of_peer) {
+            None => {
+                return;
+            }
+            Some(peer) => peer,
+        };
+    };
+}
+
+macro_rules! fetch_timers {
+    ( $peer:ident, $timers:ident) => {
+        let $timers = $peer.timers();
+        if !$timers.enabled {
+            return;
+        }
+    };
+}
+
 impl Timers {
     #[inline(always)]
     fn needs_another_keepalive(&self) -> bool {
@@ -38,27 +59,6 @@ impl Timers {
         public_key_of_peer: PublicKey,
         timers_started: bool,
     ) -> Timers {
-        macro_rules! fetch_peer {
-            ( $wg:expr_2021, $pk:expr_2021, $peer:ident) => {
-                let peers = $wg.peers.read();
-                let $peer = match peers.get(&$pk) {
-                    None => {
-                        return;
-                    }
-                    Some(peer) => peer,
-                };
-            };
-        }
-
-        macro_rules! fetch_timers {
-            ( $peer:ident, $timers:ident) => {
-                let $timers = $peer.timers();
-                if !$timers.enabled {
-                    return;
-                }
-            };
-        }
-
         let runner = wireguard_device.runner.lock();
 
         // create a timer instance for the provided peer
@@ -68,99 +68,144 @@ impl Timers {
             need_another_keepalive: AtomicBool::new(false),
             sent_lastminute_handshake: AtomicBool::new(false),
             handshake_attempts: AtomicUsize::new(0),
-            retransmit_handshake: {
-                let wg = wireguard_device.clone();
-                runner.timer(move || {
-                    // fetch peer by public key
-                    fetch_peer!(wg, public_key_of_peer, peer);
-                    fetch_timers!(peer, timers);
-
-                    // check if handshake attempts remaining
-                    let attempts = timers.handshake_attempts.fetch_add(1, Ordering::SeqCst);
-                    if attempts > MAX_TIMER_HANDSHAKES {
-                        debug!(
-                            "Handshake for peer {} did not complete after {} attempts, giving up",
-                            peer,
-                            attempts + 1
-                        );
-                        timers.send_keepalive.stop();
-                        timers.zero_key_material.start(REJECT_AFTER_TIME * 3);
-                        peer.purge_staged_packets();
-                    } else {
-                        debug!(
-                            "Handshake for {} did not complete after {} seconds, retrying (try {})",
-                            peer,
-                            REKEY_TIMEOUT.as_secs(),
-                            attempts
-                        );
-                        timers.retransmit_handshake.reset(REKEY_TIMEOUT);
-                        peer.clear_src();
-                        peer.packet_send_queued_handshake_initiation(true);
-                    }
-                })
-            },
-            send_keepalive: {
-                let wg = wireguard_device.clone();
-                runner.timer(move || {
-                    // fetch peer by public key
-                    fetch_peer!(wg, public_key_of_peer, peer);
-                    fetch_timers!(peer, timers);
-
-                    // send keepalive and schedule next keepalive
-                    peer.send_keepalive();
-                    if timers.needs_another_keepalive() {
-                        timers.send_keepalive.start(KEEPALIVE_TIMEOUT);
-                    }
-                })
-            },
-            new_handshake: {
-                let wg = wireguard_device.clone();
-                runner.timer(move || {
-                    // fetch peer by public key
-                    fetch_peer!(wg, public_key_of_peer, peer);
-                    fetch_timers!(peer, timers);
-
-                    // clear source and retry
-                    log::debug!(
-                        "Retrying handshake with {} because we stopped hearing back after {} seconds",
-                        peer,
-                        (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT).as_secs()
-                    );
-                    peer.clear_src();
-                    peer.packet_send_queued_handshake_initiation(false);
-                })
-            },
-            zero_key_material: {
-                let wg = wireguard_device.clone();
-                runner.timer(move || {
-                    // fetch peer by public key
-                    fetch_peer!(wg, public_key_of_peer, peer);
-                    log::trace!("{} : timer fired (zero_key_material)", peer);
-
-                    // null all key-material
-                    peer.zero_keys();
-                })
-            },
-            send_persistent_keepalive: {
-                let wg = wireguard_device.clone();
-                runner.timer(move || {
-                    // fetch peer by public key
-                    fetch_peer!(wg, public_key_of_peer, peer);
-                    fetch_timers!(peer, timers);
-                    log::trace!("{} : timer fired (send_persistent_keepalive)", peer);
-
-                    // send and schedule persistent keepalive
-                    if timers.keepalive_interval > 0 {
-                        timers.send_keepalive.stop();
-                        peer.send_keepalive();
-                        log::trace!("{} : keepalive queued", peer);
-                        timers
-                            .send_persistent_keepalive
-                            .start(Duration::from_secs(timers.keepalive_interval));
-                    }
-                })
-            },
+            retransmit_handshake: Self::create_retransmit_handshake_timer(
+                wireguard_device.clone(),
+                public_key_of_peer,
+                &runner,
+            ),
+            send_keepalive: Self::create_send_keepalive_timer(
+                wireguard_device.clone(),
+                public_key_of_peer,
+                &runner,
+            ),
+            new_handshake: Self::create_new_handshake_timer(
+                wireguard_device.clone(),
+                public_key_of_peer,
+                &runner,
+            ),
+            zero_key_material: Self::create_zero_key_material_timer(
+                wireguard_device.clone(),
+                public_key_of_peer,
+                &runner,
+            ),
+            send_persistent_keepalive: Self::create_send_persistent_keepalive_timer(
+                wireguard_device.clone(),
+                public_key_of_peer,
+                &runner,
+            ),
         }
+    }
+
+    fn create_retransmit_handshake_timer<T: Tun, B: UDP>(
+        wireguard_device: WireGuard<T, B>,
+        public_key_of_peer: PublicKey,
+        runner: &Runner,
+    ) -> Timer {
+        runner.timer(move || {
+            // fetch peer by public key
+            fetch_peer!(wireguard_device, public_key_of_peer, peer);
+            fetch_timers!(peer, timers);
+
+            // check if handshake attempts remaining
+            let attempts = timers.handshake_attempts.fetch_add(1, Ordering::SeqCst);
+            if attempts > MAX_TIMER_HANDSHAKES {
+                debug!(
+                    "Handshake for peer {} did not complete after {} attempts, giving up",
+                    peer,
+                    attempts + 1
+                );
+                timers.send_keepalive.stop();
+                timers.zero_key_material.start(REJECT_AFTER_TIME * 3);
+                peer.purge_staged_packets();
+            } else {
+                debug!(
+                    "Handshake for {} did not complete after {} seconds, retrying (try {})",
+                    peer,
+                    REKEY_TIMEOUT.as_secs(),
+                    attempts
+                );
+                timers.retransmit_handshake.reset(REKEY_TIMEOUT);
+                peer.clear_src();
+                peer.packet_send_queued_handshake_initiation(true);
+            }
+        })
+    }
+
+    fn create_send_keepalive_timer<T: Tun, B: UDP>(
+        wireguard_device: WireGuard<T, B>,
+        public_key_of_peer: PublicKey,
+        runner: &Runner,
+    ) -> Timer {
+        runner.timer(move || {
+            // fetch peer by public key
+            fetch_peer!(wireguard_device, public_key_of_peer, peer);
+            fetch_timers!(peer, timers);
+
+            // send keepalive and schedule next keepalive
+            peer.send_keepalive();
+            if timers.needs_another_keepalive() {
+                timers.send_keepalive.start(KEEPALIVE_TIMEOUT);
+            }
+        })
+    }
+
+    fn create_new_handshake_timer<T: Tun, B: UDP>(
+        wireguard_device: WireGuard<T, B>,
+        public_key_of_peer: PublicKey,
+        runner: &Runner,
+    ) -> Timer {
+        runner.timer(move || {
+            // fetch peer by public key
+            fetch_peer!(wireguard_device, public_key_of_peer, peer);
+            fetch_timers!(peer, timers);
+
+            // clear source and retry
+            log::debug!(
+                "Retrying handshake with {} because we stopped hearing back after {} seconds",
+                peer,
+                (KEEPALIVE_TIMEOUT + REKEY_TIMEOUT).as_secs()
+            );
+            peer.clear_src();
+            peer.packet_send_queued_handshake_initiation(false);
+        })
+    }
+
+    fn create_zero_key_material_timer<T: Tun, B: UDP>(
+        wireguard_device: WireGuard<T, B>,
+        public_key_of_peer: PublicKey,
+        runner: &Runner,
+    ) -> Timer {
+        runner.timer(move || {
+            // fetch peer by public key
+            fetch_peer!(wireguard_device, public_key_of_peer, peer);
+            log::trace!("{} : timer fired (zero_key_material)", peer);
+
+            // null all key-material
+            peer.zero_keys();
+        })
+    }
+
+    fn create_send_persistent_keepalive_timer<T: Tun, B: UDP>(
+        wireguard_device: WireGuard<T, B>,
+        public_key_of_peer: PublicKey,
+        runner: &Runner,
+    ) -> Timer {
+        runner.timer(move || {
+            // fetch peer by public key
+            fetch_peer!(wireguard_device, public_key_of_peer, peer);
+            fetch_timers!(peer, timers);
+            log::trace!("{} : timer fired (send_persistent_keepalive)", peer);
+
+            // send and schedule persistent keepalive
+            if timers.keepalive_interval > 0 {
+                timers.send_keepalive.stop();
+                peer.send_keepalive();
+                log::trace!("{} : keepalive queued", peer);
+                timers
+                    .send_persistent_keepalive
+                    .start(Duration::from_secs(timers.keepalive_interval));
+            }
+        })
     }
 
     pub fn get_keepalive_interval(&self) -> u64 {

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -34,9 +34,9 @@ impl Timers {
     }
 
     pub fn new<T: Tun, B: UDP>(
-        wg: WireGuard<T, B>, // WireGuard device
-        pk: PublicKey,       // public key of peer
-        running: bool,       // timers started
+        wireguard_device: WireGuard<T, B>,
+        public_key_of_peer: PublicKey,
+        timers_started: bool,
     ) -> Timers {
         macro_rules! fetch_peer {
             ( $wg:expr_2021, $pk:expr_2021, $peer:ident) => {
@@ -59,20 +59,20 @@ impl Timers {
             };
         }
 
-        let runner = wg.runner.lock();
+        let runner = wireguard_device.runner.lock();
 
         // create a timer instance for the provided peer
         Timers {
-            enabled: running,
+            enabled: timers_started,
             keepalive_interval: 0, // disabled
             need_another_keepalive: AtomicBool::new(false),
             sent_lastminute_handshake: AtomicBool::new(false),
             handshake_attempts: AtomicUsize::new(0),
             retransmit_handshake: {
-                let wg = wg.clone();
+                let wg = wireguard_device.clone();
                 runner.timer(move || {
                     // fetch peer by public key
-                    fetch_peer!(wg, pk, peer);
+                    fetch_peer!(wg, public_key_of_peer, peer);
                     fetch_timers!(peer, timers);
 
                     // check if handshake attempts remaining
@@ -100,10 +100,10 @@ impl Timers {
                 })
             },
             send_keepalive: {
-                let wg = wg.clone();
+                let wg = wireguard_device.clone();
                 runner.timer(move || {
                     // fetch peer by public key
-                    fetch_peer!(wg, pk, peer);
+                    fetch_peer!(wg, public_key_of_peer, peer);
                     fetch_timers!(peer, timers);
 
                     // send keepalive and schedule next keepalive
@@ -114,10 +114,10 @@ impl Timers {
                 })
             },
             new_handshake: {
-                let wg = wg.clone();
+                let wg = wireguard_device.clone();
                 runner.timer(move || {
                     // fetch peer by public key
-                    fetch_peer!(wg, pk, peer);
+                    fetch_peer!(wg, public_key_of_peer, peer);
                     fetch_timers!(peer, timers);
 
                     // clear source and retry
@@ -131,10 +131,10 @@ impl Timers {
                 })
             },
             zero_key_material: {
-                let wg = wg.clone();
+                let wg = wireguard_device.clone();
                 runner.timer(move || {
                     // fetch peer by public key
-                    fetch_peer!(wg, pk, peer);
+                    fetch_peer!(wg, public_key_of_peer, peer);
                     log::trace!("{} : timer fired (zero_key_material)", peer);
 
                     // null all key-material
@@ -142,10 +142,10 @@ impl Timers {
                 })
             },
             send_persistent_keepalive: {
-                let wg = wg.clone();
+                let wg = wireguard_device.clone();
                 runner.timer(move || {
                     // fetch peer by public key
-                    fetch_peer!(wg, pk, peer);
+                    fetch_peer!(wg, public_key_of_peer, peer);
                     fetch_timers!(peer, timers);
                     log::trace!("{} : timer fired (send_persistent_keepalive)", peer);
 

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -39,8 +39,10 @@ macro_rules! fetch_peer {
     };
 }
 
-macro_rules! fetch_timers {
-    ( $peer:ident, $timers:ident) => {
+macro_rules! fetch_peer_and_timers {
+    ( $wireguard_device:expr_2021, $public_key_of_peer:expr_2021, $peer:ident, $timers:ident) => {
+        fetch_peer!($wireguard_device, $public_key_of_peer, $peer);
+
         let $timers = $peer.timers();
         if !$timers.enabled {
             return;
@@ -102,9 +104,8 @@ impl Timers {
         runner: &Runner,
     ) -> Timer {
         runner.timer(move || {
-            // fetch peer by public key
-            fetch_peer!(wireguard_device, public_key_of_peer, peer);
-            fetch_timers!(peer, timers);
+            // create variables 'peer' and 'timers'
+            fetch_peer_and_timers!(wireguard_device, public_key_of_peer, peer, timers);
 
             // check if handshake attempts remaining
             let attempts = timers.handshake_attempts.fetch_add(1, Ordering::SeqCst);
@@ -137,9 +138,8 @@ impl Timers {
         runner: &Runner,
     ) -> Timer {
         runner.timer(move || {
-            // fetch peer by public key
-            fetch_peer!(wireguard_device, public_key_of_peer, peer);
-            fetch_timers!(peer, timers);
+            // create variables 'peer' and 'timers'
+            fetch_peer_and_timers!(wireguard_device, public_key_of_peer, peer, timers);
 
             // send keepalive and schedule next keepalive
             peer.send_keepalive();
@@ -155,9 +155,8 @@ impl Timers {
         runner: &Runner,
     ) -> Timer {
         runner.timer(move || {
-            // fetch peer by public key
+            // create variable 'peer'
             fetch_peer!(wireguard_device, public_key_of_peer, peer);
-            fetch_timers!(peer, timers);
 
             // clear source and retry
             log::debug!(
@@ -176,8 +175,9 @@ impl Timers {
         runner: &Runner,
     ) -> Timer {
         runner.timer(move || {
-            // fetch peer by public key
+            // create variable 'peer'
             fetch_peer!(wireguard_device, public_key_of_peer, peer);
+
             log::trace!("{} : timer fired (zero_key_material)", peer);
 
             // null all key-material
@@ -191,9 +191,9 @@ impl Timers {
         runner: &Runner,
     ) -> Timer {
         runner.timer(move || {
-            // fetch peer by public key
-            fetch_peer!(wireguard_device, public_key_of_peer, peer);
-            fetch_timers!(peer, timers);
+            // create variables 'peer' and 'timers'
+            fetch_peer_and_timers!(wireguard_device, public_key_of_peer, peer, timers);
+
             log::trace!("{} : timer fired (send_persistent_keepalive)", peer);
 
             // send and schedule persistent keepalive

--- a/src/wireguard/timers.rs
+++ b/src/wireguard/timers.rs
@@ -277,6 +277,7 @@ impl Timers {
         }
     }
 
+    /// Return true if timers are enabled, false otherwise
     pub fn stop_retransmit_handshake_timer(&self) -> bool {
         if self.enabled {
             self.retransmit_handshake.stop();
@@ -320,6 +321,7 @@ impl Timers {
         self.handshake_attempts.store(0, Ordering::SeqCst);
     }
 
+    /// Return true if the event hasn't been registered before this call, otherwise false
     pub fn register_lastminute_handshake_sent(&self) -> bool {
         !self.sent_lastminute_handshake.swap(true, Ordering::Acquire)
     }


### PR DESCRIPTION
Move PeerInner implementations from timers.rs to peer.rs
Create public interface for Timers, make PeerInner use this interface
Split new() into smaller functions, reorganize macros so that only 1 macro needs to be called in each callback