### PR TITLE
Remove wait counter

### DIFF
--- a/src/platform/macos/tun.rs
+++ b/src/platform/macos/tun.rs
@@ -2,11 +2,7 @@ use crate::{platform::plt::fd::Fd, platform::tun::*};
 
 use libc::{IFNAMSIZ, socklen_t};
 use nix::ioctl_readwrite;
-use std::{
-    fmt,
-    io,
-    mem,
-};
+use std::{fmt, io, mem};
 
 // CTLIOCGINFO ioctl: get id from a control name
 // From sys/kern_control.h: _IOWR('N', 3, struct ctl_info)

--- a/src/platform/macos/udp.rs
+++ b/src/platform/macos/udp.rs
@@ -1,5 +1,5 @@
-use super::super::udp::*;
 use super::super::Endpoint;
+use super::super::udp::*;
 
 use std::fmt;
 use std::io::{IoSlice, IoSliceMut};
@@ -8,10 +8,9 @@ use std::os::fd::{IntoRawFd, RawFd};
 
 use nix::cmsg_space;
 use nix::sys::socket::{
-    self, bind, getsockname, recvmsg, sendmsg, setsockopt, socket,
+    self, AddressFamily, ControlMessage, ControlMessageOwned, MsgFlags, SockFlag, SockProtocol,
+    SockType, SockaddrIn, SockaddrIn6, bind, getsockname, recvmsg, sendmsg, setsockopt, socket,
     sockopt::{Ipv4RecvDstAddr, Ipv4RecvIf, Ipv6RecvPacketInfo, ReuseAddr, ReusePort},
-    AddressFamily, ControlMessage, ControlMessageOwned, MsgFlags, SockFlag, SockProtocol,
-    SockType, SockaddrIn, SockaddrIn6,
 };
 use std::sync::Arc;
 
@@ -156,7 +155,10 @@ impl UdpSocket {
     fn validate_sockaddr(addr: socket::SockaddrStorage) -> Result<SocketAddr> {
         addr.as_sockaddr_in()
             .map(|sin| SocketAddr::V4((*sin).into()))
-            .or_else(|| addr.as_sockaddr_in6().map(|sin6| SocketAddr::V6((*sin6).into())))
+            .or_else(|| {
+                addr.as_sockaddr_in6()
+                    .map(|sin6| SocketAddr::V6((*sin6).into()))
+            })
             .ok_or_else(|| UdpError::InvalidAddress(format!("{:?}", addr)))
     }
 
@@ -190,7 +192,8 @@ impl UdpSocket {
             let mut destination_addr = None;
             let mut if_index = None;
 
-            let src_addr_info = msg.address
+            let src_addr_info = msg
+                .address
                 .and_then(|addr| addr.as_sockaddr_in().copied())
                 .ok_or_else(|| UdpError::InvalidAddress(format!("{:?}", msg.address)))?;
 
@@ -220,7 +223,8 @@ impl UdpSocket {
                 }
             }
         } else {
-            let src_addr_info = msg.address
+            let src_addr_info = msg
+                .address
                 .and_then(|addr| addr.as_sockaddr_in6().copied())
                 .ok_or_else(|| UdpError::InvalidAddress(format!("{:?}", msg.address)))?;
 
@@ -400,10 +404,7 @@ impl Endpoint for MacosEndpoint {
                 *src_if_index = 0;
                 *src_addr = libc::in_addr { s_addr: 0u32 };
             }
-            Self::V6 {
-                src_if_index,
-                ..
-            } => {
+            Self::V6 { src_if_index, .. } => {
                 *src_if_index = 0;
             }
         }

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -50,7 +50,7 @@ fn run(config: Config) -> Result<(), ErrorReason> {
     profiler_start(name.as_str());
 
     let wireguard_handle: WireGuardHandle<plt::Tun, plt::UDP> =
-        WireGuardHandle::new(tun_readers, tun_writer);
+        WireGuardHandle::spawn(tun_readers, tun_writer);
 
     let wireguard_config = WireGuardConfig::new(wireguard_handle.get_device().clone());
 
@@ -59,7 +59,7 @@ fn run(config: Config) -> Result<(), ErrorReason> {
     spawn_uapi_server(wireguard_config, uapi_socket);
 
     // block until all tun readers closed
-    wireguard_handle.wait();
+    wireguard_handle.join();
 
     profiler_stop();
 

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -12,7 +12,7 @@ use crate::platform::{
     uapi::{BindUAPI, PlatformUAPI},
     udp::PlatformUDP,
 };
-use crate::wireguard::WireGuard;
+use crate::wireguard::WireGuardHandle;
 
 use super::config::Config;
 use super::error::{ErrorReason, ExitCode};
@@ -32,7 +32,7 @@ fn run(config: Config) -> Result<(), ErrorReason> {
     let uapi_socket = plt::UAPI::bind(name.as_str())
         .map_err(|e| ErrorReason::UAPIListenerCreationFailed(anyhow!(e)))?;
 
-    let (mut tun_readers, tun_writer, tun_status) = plt::Tun::create(name.as_str())
+    let (tun_readers, tun_writer, tun_status) = plt::Tun::create(name.as_str())
         .map_err(|e| ErrorReason::TUNDeviceCreationFailed(anyhow!(e)))?;
 
     if config.drop_privileges {
@@ -49,20 +49,17 @@ fn run(config: Config) -> Result<(), ErrorReason> {
 
     profiler_start(name.as_str());
 
-    let wireguard_device: WireGuard<plt::Tun, plt::UDP> = WireGuard::new(tun_writer);
+    let wireguard_handle: WireGuardHandle<plt::Tun, plt::UDP> =
+        WireGuardHandle::new(tun_readers, tun_writer);
 
-    while let Some(reader) = tun_readers.pop() {
-        wireguard_device.add_tun_reader(reader);
-    }
-
-    let wireguard_config = WireGuardConfig::new(wireguard_device.clone());
+    let wireguard_config = WireGuardConfig::new(wireguard_handle.get_device().clone());
 
     spawn_tun_event_loop(wireguard_config.clone(), tun_status);
 
     spawn_uapi_server(wireguard_config, uapi_socket);
 
     // block until all tun readers closed
-    wireguard_device.wait();
+    wireguard_handle.wait();
 
     profiler_stop();
 

--- a/src/wireguard/mod.rs
+++ b/src/wireguard/mod.rs
@@ -13,6 +13,7 @@ mod queue;
 mod router;
 mod timers;
 mod types;
+mod wireguard_handle;
 mod workers;
 
 #[cfg(test)]
@@ -23,6 +24,7 @@ mod wireguard;
 
 // represents a WireGuard interface
 pub use wireguard::WireGuard;
+pub use wireguard_handle::WireGuardHandle;
 
 #[cfg(test)]
 use super::platform::dummy;

--- a/src/wireguard/tests.rs
+++ b/src/wireguard/tests.rs
@@ -76,13 +76,13 @@ fn test_pure_wireguard() {
 
     let (fake1, tun_reader1, tun_writer1, _) = dummy::TunTest::create(true);
     let wg1_handle: WireGuardHandle<dummy::TunTest, dummy::PairBind> =
-        WireGuardHandle::new(vec![tun_reader1], tun_writer1);
+        WireGuardHandle::spawn(vec![tun_reader1], tun_writer1);
     let wg1 = wg1_handle.get_device();
     wg1.up(1500);
 
     let (fake2, tun_reader2, tun_writer2, _) = dummy::TunTest::create(true);
     let wg2_handle: WireGuardHandle<dummy::TunTest, dummy::PairBind> =
-        WireGuardHandle::new(vec![tun_reader2], tun_writer2);
+        WireGuardHandle::spawn(vec![tun_reader2], tun_writer2);
     let wg2 = wg2_handle.get_device();
     wg2.up(1500);
 

--- a/src/wireguard/tests.rs
+++ b/src/wireguard/tests.rs
@@ -1,5 +1,5 @@
 use super::dummy;
-use super::wireguard::WireGuard;
+use super::wireguard_handle::WireGuardHandle;
 
 use std::convert::TryInto;
 use std::net::IpAddr;
@@ -75,13 +75,15 @@ fn test_pure_wireguard() {
     // create WG instances for dummy TUN devices
 
     let (fake1, tun_reader1, tun_writer1, _) = dummy::TunTest::create(true);
-    let wg1: WireGuard<dummy::TunTest, dummy::PairBind> = WireGuard::new(tun_writer1);
-    wg1.add_tun_reader(tun_reader1);
+    let wg1_handle: WireGuardHandle<dummy::TunTest, dummy::PairBind> =
+        WireGuardHandle::new(vec![tun_reader1], tun_writer1);
+    let wg1 = wg1_handle.get_device();
     wg1.up(1500);
 
     let (fake2, tun_reader2, tun_writer2, _) = dummy::TunTest::create(true);
-    let wg2: WireGuard<dummy::TunTest, dummy::PairBind> = WireGuard::new(tun_writer2);
-    wg2.add_tun_reader(tun_reader2);
+    let wg2_handle: WireGuardHandle<dummy::TunTest, dummy::PairBind> =
+        WireGuardHandle::new(vec![tun_reader2], tun_writer2);
+    let wg2 = wg2_handle.get_device();
     wg2.up(1500);
 
     // create pair bind to connect the interfaces "over the internet"

--- a/src/wireguard/wireguard.rs
+++ b/src/wireguard/wireguard.rs
@@ -10,15 +10,13 @@ use super::workers::HandshakeJob;
 use super::tun::Tun;
 use super::udp::UDP;
 
-use super::workers::{handshake_worker, tun_worker, udp_worker};
+use super::workers::{handshake_worker, udp_worker};
 
 use std::fmt;
 use std::thread;
 
 use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::Condvar;
-use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Instant;
 
@@ -38,9 +36,6 @@ pub struct WireguardInner<T: Tun, B: UDP> {
 
     // device enabled
     pub enabled: RwLock<bool>,
-
-    // number of tun readers
-    pub tun_readers: WaitCounter,
 
     // current MTU
     pub mtu: AtomicUsize,
@@ -64,8 +59,6 @@ pub struct WireGuard<T: Tun, B: UDP> {
     inner: Arc<WireguardInner<T, B>>,
 }
 
-pub struct WaitCounter(StdMutex<usize>, Condvar);
-
 impl<T: Tun, B: UDP> fmt::Display for WireGuard<T, B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "wireguard({:x})", self.id)
@@ -84,33 +77,6 @@ impl<T: Tun, B: UDP> Clone for WireGuard<T, B> {
         WireGuard {
             inner: self.inner.clone(),
         }
-    }
-}
-
-#[allow(clippy::mutex_atomic)]
-impl WaitCounter {
-    pub fn wait(&self) {
-        let mut nread = self.0.lock().unwrap();
-        while *nread > 0 {
-            nread = self.1.wait(nread).unwrap();
-        }
-    }
-
-    fn new() -> Self {
-        Self(StdMutex::new(0), Condvar::new())
-    }
-
-    fn decrease(&self) {
-        let mut nread = self.0.lock().unwrap();
-        assert!(*nread > 0);
-        *nread -= 1;
-        if *nread == 0 {
-            self.1.notify_all();
-        }
-    }
-
-    fn increase(&self) {
-        *self.0.lock().unwrap() += 1;
     }
 }
 
@@ -248,23 +214,6 @@ impl<T: Tun, B: UDP> WireGuard<T, B> {
         self.router.set_outbound_writer(writer);
     }
 
-    pub fn add_tun_reader(&self, reader: T::Reader) {
-        let wg = self.clone();
-
-        // increment reader count
-        wg.tun_readers.increase();
-
-        // start worker
-        thread::spawn(move || {
-            tun_worker(&wg, reader);
-            wg.tun_readers.decrease();
-        });
-    }
-
-    pub fn wait(&self) {
-        self.tun_readers.wait();
-    }
-
     pub fn new(writer: T::Writer) -> WireGuard<T, B> {
         // workers equal to number of physical cores
         let cpus = num_cpus::get();
@@ -280,7 +229,6 @@ impl<T: Tun, B: UDP> WireGuard<T, B> {
         let wg = WireGuard {
             inner: Arc::new(WireguardInner {
                 enabled: RwLock::new(false),
-                tun_readers: WaitCounter::new(),
                 id: OsRng.r#gen(),
                 mtu: AtomicUsize::new(0),
                 last_under_load: Mutex::new(Instant::now() - TIME_HORIZON),

--- a/src/wireguard/wireguard_handle.rs
+++ b/src/wireguard/wireguard_handle.rs
@@ -1,0 +1,55 @@
+use crate::platform::tun::Tun;
+use crate::platform::udp::UDP;
+
+use super::wireguard::WireGuard;
+
+use super::workers::tun_worker;
+
+use std::thread::{self, JoinHandle};
+
+pub struct WireGuardHandle<T: Tun, B: UDP> {
+    wireguard_device: WireGuard<T, B>,
+
+    tun_readers: Vec<JoinHandle<()>>,
+}
+
+impl<T: Tun, B: UDP> WireGuardHandle<T, B> {
+    pub fn new(readers: Vec<T::Reader>, writer: T::Writer) -> WireGuardHandle<T, B> {
+        let wireguard_device = WireGuard::new(writer);
+        let tun_readers = Self::start_tun_reader_jobs(&wireguard_device, readers);
+
+        WireGuardHandle {
+            wireguard_device,
+            tun_readers,
+        }
+    }
+
+    pub fn get_device(&self) -> &WireGuard<T, B> {
+        &self.wireguard_device
+    }
+
+    fn start_tun_reader_jobs(
+        wireguard_device: &WireGuard<T, B>,
+        readers: Vec<T::Reader>,
+    ) -> Vec<JoinHandle<()>> {
+        let mut result = Vec::with_capacity(readers.len());
+
+        for reader in readers {
+            result.push({
+                let wireguard_device = wireguard_device.clone();
+
+                thread::spawn(move || {
+                    tun_worker(&wireguard_device, reader);
+                })
+            });
+        }
+
+        result
+    }
+
+    pub fn wait(self) {
+        for tun_reader in self.tun_readers {
+            let _ = tun_reader.join();
+        }
+    }
+}

--- a/src/wireguard/wireguard_handle.rs
+++ b/src/wireguard/wireguard_handle.rs
@@ -11,9 +11,19 @@ pub struct WireGuardHandle<T: Tun, B: UDP> {
 }
 
 impl<T: Tun, B: UDP> WireGuardHandle<T, B> {
-    pub fn new(readers: Vec<T::Reader>, writer: T::Writer) -> WireGuardHandle<T, B> {
+    pub fn spawn(readers: Vec<T::Reader>, writer: T::Writer) -> WireGuardHandle<T, B> {
         let wireguard_device = WireGuard::new(writer);
-        let tun_readers = Self::start_tun_reader_jobs(&wireguard_device, readers);
+
+        let tun_readers = readers
+            .into_iter()
+            .map(|reader| {
+                let wireguard_device = wireguard_device.clone();
+
+                thread::spawn(move || {
+                    tun_worker(&wireguard_device, reader);
+                })
+            })
+            .collect();
 
         WireGuardHandle {
             wireguard_device,
@@ -25,26 +35,7 @@ impl<T: Tun, B: UDP> WireGuardHandle<T, B> {
         &self.wireguard_device
     }
 
-    fn start_tun_reader_jobs(
-        wireguard_device: &WireGuard<T, B>,
-        readers: Vec<T::Reader>,
-    ) -> Vec<JoinHandle<()>> {
-        let mut result = Vec::with_capacity(readers.len());
-
-        for reader in readers {
-            result.push({
-                let wireguard_device = wireguard_device.clone();
-
-                thread::spawn(move || {
-                    tun_worker(&wireguard_device, reader);
-                })
-            });
-        }
-
-        result
-    }
-
-    pub fn wait(self) {
+    pub fn join(self) {
         for tun_reader in self.tun_readers {
             let _ = tun_reader.join();
         }

--- a/src/wireguard/wireguard_handle.rs
+++ b/src/wireguard/wireguard_handle.rs
@@ -1,9 +1,6 @@
-use crate::platform::tun::Tun;
-use crate::platform::udp::UDP;
+use crate::platform::{tun::Tun, udp::UDP};
 
-use super::wireguard::WireGuard;
-
-use super::workers::tun_worker;
+use super::{wireguard::WireGuard, workers::tun_worker};
 
 use std::thread::{self, JoinHandle};
 


### PR DESCRIPTION
Create WireGuardHandle which is a single, non-cloneable instance that holds the WireGuard device.
This handle also contains JoinHandle-s for the tun reader jobs.
In this setup, we no longer need WaitCounter, as the join handles can be used to wait on running jobs.