### PR TITLE
Expand CI Checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y wireguard-tools
     - name: Setup Docker (macOS)
       if: runner.os == 'macOS'
-      uses: douglascamata/setup-docker-macos-action@v1-alpha
+      uses: douglascamata/setup-docker-macos-action@v1.0.1
     - name: Install WireGuard tools (macOS)
       if: runner.os == 'macOS'
       run: brew install wireguard-tools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   ci:
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-latest
           - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
@@ -39,11 +39,9 @@ jobs:
     - name: Install WireGuard tools (Linux)
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y wireguard-tools
-    - name: Setup Docker (macOS)
-      if: runner.os == 'macOS'
-      uses: douglascamata/setup-docker-macos-action@v1.0.1
-    - name: Install WireGuard tools (macOS)
-      if: runner.os == 'macOS'
-      run: brew install wireguard-tools
-    - name: Run Continuous Integration Checks
+    - name: Run Continuous Integration Checks (Linux)
+      if: runner.os == 'Linux'
       run: just ci
+    - name: Run Continuous Integration Checks (macOS)
+      if: runner.os == 'macOS'
+      run: just build check-fmt test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
@@ -39,5 +39,11 @@ jobs:
     - name: Install WireGuard tools (Linux)
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y wireguard-tools
+    - name: Setup Docker (macOS)
+      if: runner.os == 'macOS'
+      uses: douglascamata/setup-docker-macos-action@v1-alpha
+    - name: Install WireGuard tools (macOS)
+      if: runner.os == 'macOS'
+      run: brew install wireguard-tools
     - name: Run Continuous Integration Checks
       run: just ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ jobs:
   ci:
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-  
+  ci:
+
     strategy:
       matrix:
         os:
@@ -28,9 +28,15 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          ~/.cargo/bin
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: RUST_BACKTRACE=1 cargo test --verbose
+    - name: Install cargo-hack
+      run: cargo install cargo-hack --locked
+    - name: Install just
+      uses: extractions/setup-just@v2
+    - name: Install WireGuard tools (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y wireguard-tools
+    - name: Run Continuous Integration Checks
+      run: just ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install cargo-hack
-      run: cargo install cargo-hack --locked
+      run: cargo install cargo-hack --locked || [ -f ~/.cargo/bin/cargo-hack ]
     - name: Install just
       uses: extractions/setup-just@v2
     - name: Install WireGuard tools (Linux)

--- a/docker/run-tests-linux.sh
+++ b/docker/run-tests-linux.sh
@@ -147,7 +147,7 @@ if ! ping -c 10 -W 2 10.100.0.1; then
 fi
 
 echo "[+] Testing IPv6 ping to server (fd00::1)..."
-if ! ping -6 -c 10 -i 1 fd00::1%"$INTERFACE"; then
+if ! ping6 -c 10 -i 1 fd00::1; then
     echo "[-] IPv6 ping failed"
     exit -1
 fi

--- a/docker/run-tests-linux.sh
+++ b/docker/run-tests-linux.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# The following is an integration test for use on Linux.
+# It creates a WireGuard server running in a Docker container
+# and a client running on the host machine.
+
+set -e
+
+INTERFACE="wg10"
+
+cleanup() {
+    echo "[+] Cleaning up..."
+    docker compose -f docker-compose.yml down 2>/dev/null || true
+    sudo pkill -9 wireguard-rs 2>/dev/null || true
+    sleep 1
+
+    if ip link show "$INTERFACE" >/dev/null 2>&1; then
+        echo "Warning: $INTERFACE still exists after cleanup"
+        sudo ip link delete "$INTERFACE" 2>/dev/null || true
+    fi
+
+    rm -f /tmp/wg_client.log /tmp/client_key 2>/dev/null || true
+    echo "[+] Cleanup complete"
+}
+
+trap cleanup EXIT
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <path-to-wireguard-rs-binary>"
+    exit 1
+fi
+
+program="$1"
+
+if [ ! -x "$program" ]; then
+    echo "[-] Error: $program does not exist or is not executable"
+    exit 1
+fi
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Load keys from files
+SERVER_SECRET_KEY=$(cat server-sk.key)
+SERVER_PUBLIC_KEY=$(cat server-pk.key)
+CLIENT_SECRET_KEY=$(cat client-sk.key)
+CLIENT_PUBLIC_KEY=$(cat client-pk.key)
+
+echo "[+] Creating WireGuard server config..."
+echo "[+] Server public key: $SERVER_PUBLIC_KEY"
+echo "[+] Client public key: $CLIENT_PUBLIC_KEY"
+
+# Clean up old config and create new one
+rm -rf wireguard 2>/dev/null || true
+mkdir -p wireguard/wg_confs
+
+# Create WireGuard config before starting container
+cat > wireguard/wg_confs/wg0.conf <<EOF
+[Interface]
+ PrivateKey = $SERVER_SECRET_KEY
+Address = 10.100.0.1/24, fd00::1/64
+ListenPort = 51820
+
+[Peer]
+PublicKey = $CLIENT_PUBLIC_KEY
+AllowedIPs = 10.100.0.2/32, fd00::2/128
+EOF
+
+# cleanup any existing wireguard-rs
+echo "[+] Cleaning up any existing wireguard-rs instances"
+sudo pkill -9 wireguard-rs 2>/dev/null || true
+sudo rm -rf /var/run/wireguard 2>/dev/null || true
+sleep 1
+
+echo "[+] Starting Dockerized WireGuard server"
+docker compose -f docker-compose.yml up -d
+sleep 1
+
+# start wireguard-rs
+echo "[+] Starting wireguard-rs on $INTERFACE"
+export RUST_LOG=trace
+sudo -E "$program" "$INTERFACE" > /tmp/wg_client.log 2>&1 &
+WG_PID=$!
+sleep 1
+
+# wait for interface
+for i in {1..20}; do
+    if ip link show "$INTERFACE" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+if ! ip link show "$INTERFACE" >/dev/null 2>&1; then
+    echo "[-] Error: $INTERFACE did not come up"
+    cat /tmp/wg_client.log
+    exit 1
+fi
+
+# configure interface
+sudo ip addr add 10.100.0.2/24 dev "$INTERFACE"
+sudo ip addr add fd00::2/64 dev "$INTERFACE"
+sudo ip link set "$INTERFACE" up
+
+# configure WireGuard peer for the server
+echo "[+] Configuring WireGuard peer"
+sudo wg set "$INTERFACE" \
+    private-key client-sk.key \
+    listen-port 0 \
+    peer "$SERVER_PUBLIC_KEY" \
+        allowed-ips 10.100.0.1/32,fd00::1/128 \
+        endpoint 127.0.0.1:51821 \
+        persistent-keepalive 25
+
+# Add routes
+echo "[+] Updating routing table"
+sudo ip route add 10.100.0.1/32 dev "$INTERFACE" 2>/dev/null || true
+sudo ip -6 route add fd00::1/128 dev "$INTERFACE" 2>/dev/null || true
+
+echo "[+] WireGuard Configuration:"
+sudo wg show "$INTERFACE"
+
+echo ""
+echo "[+] Sending ping to trigger handshake..."
+ping -c 1 -W 1 10.100.0.1 >/dev/null 2>&1 || true
+sleep 1
+
+echo "[+] Check that handshake completed successfully"
+sudo wg show "$INTERFACE"
+
+# Check if handshake happened
+if ! sudo wg show "$INTERFACE" | grep -q "latest handshake"; then
+	echo "[-] Handshake Failed."
+    echo ""
+    echo "Client logs:"
+    cat /tmp/wg_client.log
+    echo ""
+    echo "Server logs:"
+    docker compose -f docker-compose.yml logs wireguard-server
+	exit -1
+fi
+echo "[+] Testing IPv4 ping to server (10.100.0.1)..."
+if ! ping -c 10 -W 2 10.100.0.1; then
+	echo "[-] IPv4 ping failed"
+	exit -1
+fi
+
+echo "[+] Testing IPv6 ping to server (fd00::1)..."
+if ! ping -6 -c 10 -i 1 fd00::1%"$INTERFACE"; then
+    echo "[-] IPv6 ping failed"
+    exit -1
+fi
+
+echo "[+] All tests successful (IPv4 and IPv6)."

--- a/docker/run-tests-macos.sh
+++ b/docker/run-tests-macos.sh
@@ -6,14 +6,18 @@
 
 set -e
 
+INTERFACE="utun10"
+
 cleanup() {
     echo "[+] Cleaning up..."
     docker compose -f docker-compose.yml down 2>/dev/null || true
     sudo pkill -9 wireguard-rs 2>/dev/null || true
     sleep 1
-    if ifconfig utun10 >/dev/null 2>&1; then
-        echo "Warning: utun10 still exists after cleanup"
+
+    if ifconfig "$INTERFACE" >/dev/null 2>&1; then
+        echo "Warning: $INTERFACE still exists after cleanup"
     fi
+
     rm -f /tmp/wg_client.log /tmp/client_key 2>/dev/null || true
     echo "[+] Cleanup complete"
 }
@@ -53,7 +57,7 @@ mkdir -p wireguard/wg_confs
 # Create WireGuard config before starting container
 cat > wireguard/wg_confs/wg0.conf <<EOF
 [Interface]
-PrivateKey = $SERVER_SECRET_KEY
+ PrivateKey = $SERVER_SECRET_KEY
 Address = 10.100.0.1/24, fd00::1/64
 ListenPort = 51820
 
@@ -73,34 +77,34 @@ docker compose -f docker-compose.yml up -d
 sleep 1
 
 # start wireguard-rs
-echo "[+] Starting wireguard-rs on utun10"
+echo "[+] Starting wireguard-rs on $INTERFACE"
 export RUST_LOG=trace
-sudo -E "$program" utun10 > /tmp/wg_client.log 2>&1 &
+sudo -E "$program" "$INTERFACE" > /tmp/wg_client.log 2>&1 &
 WG_PID=$!
 sleep 1
 
 # wait for interface
 for i in {1..20}; do
-    if ifconfig utun10 >/dev/null 2>&1; then
+    if ifconfig "$INTERFACE" >/dev/null 2>&1; then
         break
     fi
     sleep 0.5
 done
 
-if ! ifconfig utun10 >/dev/null 2>&1; then
-    echo "[-] Error: utun10 did not come up"
+if ! ifconfig "$INTERFACE" >/dev/null 2>&1; then
+    echo "[-] Error: $INTERFACE did not come up"
     cat /tmp/wg_client.log
     exit 1
 fi
 
 # configure interface
-sudo ifconfig utun10 inet 10.100.0.2/24 10.100.0.2
-sudo ifconfig utun10 inet6 fd00::2/64
-sudo ifconfig utun10 up
+sudo ifconfig "$INTERFACE" inet 10.100.0.2/24 10.100.0.2
+sudo ifconfig "$INTERFACE" inet6 fd00::2/64
+sudo ifconfig "$INTERFACE" up
 
 # configure WireGuard peer for the server
 echo "[+] Configuring WireGuard peer"
-sudo wg set utun10 \
+sudo wg set "$INTERFACE" \
     private-key client-sk.key \
     listen-port 0 \
     peer "$SERVER_PUBLIC_KEY" \
@@ -111,12 +115,12 @@ sudo wg set utun10 \
 # Add routes
 echo "[+] Updating routing table"
 sudo route -n delete -host 10.100.0.1 2>/dev/null || true
-sudo route -n add -host 10.100.0.1 -interface utun10
+sudo route -n add -host 10.100.0.1 -interface "$INTERFACE"
 sudo route -n delete -inet6 -host fd00::1 2>/dev/null || true
-sudo route -n add -inet6 -host fd00::1 -interface utun10
+sudo route -n add -inet6 -host fd00::1 -interface "$INTERFACE"
 
 echo "[+] WireGuard Configuration:"
-sudo wg show utun10
+sudo wg show "$INTERFACE"
 
 echo ""
 echo "[+] Sending ping to trigger handshake..."
@@ -124,10 +128,10 @@ ping -c 1 -W 1 10.100.0.1 >/dev/null 2>&1 || true
 sleep 1
 
 echo "[+] Check that handshake completed successfully"
-sudo wg show utun10
+sudo wg show "$INTERFACE"
 
 # Check if handshake happened
-if ! sudo wg show utun10 | grep -q "latest handshake"; then
+if ! sudo wg show "$INTERFACE" | grep -q "latest handshake"; then
 	echo "[-] Handshake Failed."
     echo ""
     echo "Client logs:"
@@ -144,9 +148,9 @@ if ! ping -c 10 -W 2 10.100.0.1; then
 fi
 
 echo "[+] Testing IPv6 ping to server (fd00::1)..."
-if ! ping6 -c 10 -i 1 fd00::1%utun10; then
-	echo "[-] IPv6 ping failed"
-	exit -1
+if ! ping6 -c 10 -i 1 fd00::1%"$INTERFACE"; then
+    echo "[-] IPv6 ping failed"
+    exit -1
 fi
 
 echo "[+] All tests successful (IPv4 and IPv6)."

--- a/justfile
+++ b/justfile
@@ -1,0 +1,30 @@
+build:
+    cargo build --release
+
+test:
+    cargo test --verbose
+
+fmt:
+    cargo fmt
+
+check-fmt:
+    cargo fmt --check
+
+check-clippy:
+    cargo clippy -- -D warnings
+
+check-build:
+    cargo hack check --feature-powerset
+
+integration: build
+    #!/usr/bin/env bash
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        cd docker && ./run-tests-macos.sh ../target/release/wireguard-rs
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        cd docker && ./run-tests-linux.sh ../target/release/wireguard-rs
+    else
+        echo "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+
+ci: build check-fmt test integration

--- a/src/platform/macos/tun.rs
+++ b/src/platform/macos/tun.rs
@@ -2,11 +2,7 @@ use crate::{platform::plt::fd::Fd, platform::tun::*};
 
 use libc::{IFNAMSIZ, socklen_t};
 use nix::ioctl_readwrite;
-use std::{
-    fmt,
-    io,
-    mem,
-};
+use std::{fmt, io, mem};
 
 // CTLIOCGINFO ioctl: get id from a control name
 // From sys/kern_control.h: _IOWR('N', 3, struct ctl_info)

--- a/src/platform/macos/udp.rs
+++ b/src/platform/macos/udp.rs
@@ -1,5 +1,5 @@
-use super::super::udp::*;
 use super::super::Endpoint;
+use super::super::udp::*;
 
 use std::fmt;
 use std::io::{IoSlice, IoSliceMut};
@@ -8,10 +8,9 @@ use std::os::fd::{IntoRawFd, RawFd};
 
 use nix::cmsg_space;
 use nix::sys::socket::{
-    self, bind, getsockname, recvmsg, sendmsg, setsockopt, socket,
+    self, AddressFamily, ControlMessage, ControlMessageOwned, MsgFlags, SockFlag, SockProtocol,
+    SockType, SockaddrIn, SockaddrIn6, bind, getsockname, recvmsg, sendmsg, setsockopt, socket,
     sockopt::{Ipv4RecvDstAddr, Ipv4RecvIf, Ipv6RecvPacketInfo, ReuseAddr, ReusePort},
-    AddressFamily, ControlMessage, ControlMessageOwned, MsgFlags, SockFlag, SockProtocol,
-    SockType, SockaddrIn, SockaddrIn6,
 };
 use std::sync::Arc;
 
@@ -156,7 +155,10 @@ impl UdpSocket {
     fn validate_sockaddr(addr: socket::SockaddrStorage) -> Result<SocketAddr> {
         addr.as_sockaddr_in()
             .map(|sin| SocketAddr::V4((*sin).into()))
-            .or_else(|| addr.as_sockaddr_in6().map(|sin6| SocketAddr::V6((*sin6).into())))
+            .or_else(|| {
+                addr.as_sockaddr_in6()
+                    .map(|sin6| SocketAddr::V6((*sin6).into()))
+            })
             .ok_or_else(|| UdpError::InvalidAddress(format!("{:?}", addr)))
     }
 
@@ -190,7 +192,8 @@ impl UdpSocket {
             let mut destination_addr = None;
             let mut if_index = None;
 
-            let src_addr_info = msg.address
+            let src_addr_info = msg
+                .address
                 .and_then(|addr| addr.as_sockaddr_in().copied())
                 .ok_or_else(|| UdpError::InvalidAddress(format!("{:?}", msg.address)))?;
 
@@ -220,7 +223,8 @@ impl UdpSocket {
                 }
             }
         } else {
-            let src_addr_info = msg.address
+            let src_addr_info = msg
+                .address
                 .and_then(|addr| addr.as_sockaddr_in6().copied())
                 .ok_or_else(|| UdpError::InvalidAddress(format!("{:?}", msg.address)))?;
 
@@ -400,10 +404,7 @@ impl Endpoint for MacosEndpoint {
                 *src_if_index = 0;
                 *src_addr = libc::in_addr { s_addr: 0u32 };
             }
-            Self::V6 {
-                src_if_index,
-                ..
-            } => {
+            Self::V6 { src_if_index, .. } => {
                 *src_if_index = 0;
             }
         }


### PR DESCRIPTION
Adds:

- Integration tests
- Cargo fmt
- Cargo check (for all features)

I wanted to add `cargo clippy` but the diff is large, we should do that separately.

I also introduced a `justfile` (https://github.com/casey/just), which works like `make` with every target being `.PHONY`. 

To run the CI checks locally:

```
just ci
```