### PR TITLE
Rewrite rate limiter

### DIFF
--- a/src/wireguard/handshake/device.rs
+++ b/src/wireguard/handshake/device.rs
@@ -350,12 +350,7 @@ impl<O> Device<O> {
                     }
 
                     // check ratelimiter
-                    if !self
-                        .limiter
-                        .lock()
-                        .unwrap()
-                        .try_register_new_packet(&src.ip())
-                    {
+                    if !self.limiter.lock().unwrap().check(&src.ip()) {
                         return Err(HandshakeError::RateLimited);
                     }
                 }
@@ -410,12 +405,7 @@ impl<O> Device<O> {
                     }
 
                     // check ratelimiter
-                    if !self
-                        .limiter
-                        .lock()
-                        .unwrap()
-                        .try_register_new_packet(&src.ip())
-                    {
+                    if !self.limiter.lock().unwrap().check(&src.ip()) {
                         return Err(HandshakeError::RateLimited);
                     }
                 }

--- a/src/wireguard/handshake/device.rs
+++ b/src/wireguard/handshake/device.rs
@@ -350,7 +350,12 @@ impl<O> Device<O> {
                     }
 
                     // check ratelimiter
-                    if !self.limiter.lock().unwrap().allow(&src.ip()) {
+                    if !self
+                        .limiter
+                        .lock()
+                        .unwrap()
+                        .is_new_packet_allowed(&src.ip())
+                    {
                         return Err(HandshakeError::RateLimited);
                     }
                 }
@@ -405,7 +410,12 @@ impl<O> Device<O> {
                     }
 
                     // check ratelimiter
-                    if !self.limiter.lock().unwrap().allow(&src.ip()) {
+                    if !self
+                        .limiter
+                        .lock()
+                        .unwrap()
+                        .is_new_packet_allowed(&src.ip())
+                    {
                         return Err(HandshakeError::RateLimited);
                     }
                 }

--- a/src/wireguard/handshake/device.rs
+++ b/src/wireguard/handshake/device.rs
@@ -354,7 +354,7 @@ impl<O> Device<O> {
                         .limiter
                         .lock()
                         .unwrap()
-                        .is_new_packet_allowed(&src.ip())
+                        .try_register_new_packet(&src.ip())
                     {
                         return Err(HandshakeError::RateLimited);
                     }
@@ -414,7 +414,7 @@ impl<O> Device<O> {
                         .limiter
                         .lock()
                         .unwrap()
-                        .is_new_packet_allowed(&src.ip())
+                        .try_register_new_packet(&src.ip())
                     {
                         return Err(HandshakeError::RateLimited);
                     }

--- a/src/wireguard/handshake/device.rs
+++ b/src/wireguard/handshake/device.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::collections::hash_map;
 use std::net::SocketAddr;
-use std::sync::Mutex;
 
 use byteorder::{ByteOrder, LittleEndian};
 use dashmap::DashMap;
@@ -39,7 +38,7 @@ pub struct Device<O> {
     keyst: Option<KeyState>,
     id_map: DashMap<u32, [u8; 32]>, // concurrent map
     pk_map: HashMap<[u8; 32], Peer<O>>,
-    limiter: Mutex<RateLimiter>,
+    limiter: RateLimiter,
 }
 
 pub struct Iter<'a, O> {
@@ -99,7 +98,7 @@ impl<O> Device<O> {
             keyst: None,
             id_map: DashMap::new(),
             pk_map: HashMap::new(),
-            limiter: Mutex::new(RateLimiter::new()),
+            limiter: RateLimiter::new(),
         }
     }
 
@@ -350,7 +349,7 @@ impl<O> Device<O> {
                     }
 
                     // check ratelimiter
-                    if !self.limiter.lock().unwrap().check(&src.ip()) {
+                    if !self.limiter.check(&src.ip()) {
                         return Err(HandshakeError::RateLimited);
                     }
                 }
@@ -405,7 +404,7 @@ impl<O> Device<O> {
                     }
 
                     // check ratelimiter
-                    if !self.limiter.lock().unwrap().check(&src.ip()) {
+                    if !self.limiter.check(&src.ip()) {
                         return Err(HandshakeError::RateLimited);
                     }
                 }

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -100,19 +100,19 @@ mod tests {
         let mut expected = vec![];
         let ips = vec![
             "127.0.0.1".parse().unwrap(),
-            // "192.168.1.1".parse().unwrap(),
-            // "172.167.2.3".parse().unwrap(),
-            // "97.231.252.215".parse().unwrap(),
-            // "248.97.91.167".parse().unwrap(),
-            // "188.208.233.47".parse().unwrap(),
-            // "104.2.183.179".parse().unwrap(),
-            // "72.129.46.120".parse().unwrap(),
-            // "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
-            // "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
-            // "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
-            // "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
-            // "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
-            // "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
+            "192.168.1.1".parse().unwrap(),
+            "172.167.2.3".parse().unwrap(),
+            "97.231.252.215".parse().unwrap(),
+            "248.97.91.167".parse().unwrap(),
+            "188.208.233.47".parse().unwrap(),
+            "104.2.183.179".parse().unwrap(),
+            "72.129.46.120".parse().unwrap(),
+            "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
+            "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
+            "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
+            "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
+            "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
+            "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
         for _ in 0..N_PACKETS_BURSTABLE {
@@ -159,16 +159,9 @@ mod tests {
             text: "packet following 2 packet burst",
         });
 
-        let begin = Instant::now();
-
         for item in expected {
             sleep(item.wait);
             for ip in ips.iter() {
-                println!(
-                    "ip: {}, {} ms",
-                    ip,
-                    Instant::now().duration_since(begin).as_millis()
-                );
                 assert_eq!(
                     ratelimiter.allow(&ip),
                     item.allowed,

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -11,14 +11,33 @@ pub struct RateLimiter {
 }
 
 impl RateLimiter {
+    /// Create an empty RateLimiter object.
     pub fn new() -> Self {
         RateLimiter {
             table: spin::RwLock::new(HashMap::new()),
         }
     }
 
-    /// Check if a packet is allowed. If 'ip_address' is not already registered, register it.
-    pub fn is_new_packet_allowed(&mut self, ip_address: &IpAddr) -> bool {
+    /// Check if a packet is allowed at this moment.
+    ///
+    /// If 'ip_address' is not already registered, register it.
+    pub fn try_register_new_packet(&mut self, ip_address: &IpAddr) -> bool {
+        self.try_register_new_packet_at(ip_address, Instant::now())
+    }
+
+    /// Check if 'ip_address' is already registered into the RateLimiter.
+    pub fn is_registered(&self, ip_address: &IpAddr) -> bool {
+        self.table.read().contains_key(ip_address)
+    }
+
+    /// Register 'ip_address' into the RateLimiter.
+    pub fn register(&mut self, ip_address: &IpAddr) {
+        self.table
+            .write()
+            .insert(*ip_address, spin::Mutex::new(RecordedTimes::new()));
+    }
+
+    fn try_register_new_packet_at(&mut self, ip_address: &IpAddr, time: Instant) -> bool {
         // check for existing entry (only requires read lock)
         if !self.is_registered(ip_address) {
             // add new entry (write lock)
@@ -32,19 +51,7 @@ impl RateLimiter {
             .expect("Table should contain address")
             .lock();
 
-        recorded_times.is_allowed()
-    }
-
-    /// Checks if 'ip_address' is already registered into the RateLimiter.
-    pub fn is_registered(&self, ip_address: &IpAddr) -> bool {
-        self.table.read().contains_key(ip_address)
-    }
-
-    /// Register 'ip_address' into the RateLimiter.
-    pub fn register(&mut self, ip_address: &IpAddr) {
-        self.table
-            .write()
-            .insert(*ip_address, spin::Mutex::new(RecordedTimes::new()));
+        recorded_times.record(time).is_ok()
     }
 }
 
@@ -55,16 +62,14 @@ impl RecordedTimes {
         Self(VecDeque::new())
     }
 
-    fn is_allowed(&mut self) -> bool {
+    fn is_allowed(&self, time: Instant) -> bool {
         let mut result = false;
 
-        let now = Instant::now();
-
-        let queue = &mut self.0;
+        let queue = &self.0;
 
         for i in 0..N_PACKETS_BURSTABLE {
             let allowed_for_i = queue.get(i).map_or(true, |then| {
-                now.duration_since(*then).as_nanos()
+                time.duration_since(*then).as_nanos()
                     >= MIN_PACKET_DELAY_NS as u128 * (i + 1) as u128
             });
 
@@ -75,21 +80,31 @@ impl RecordedTimes {
             }
         }
 
+        result
+    }
+
+    fn record(&mut self, time: Instant) -> Result<(), &'static str> {
+        if !self.is_allowed(time) {
+            return Err("not allowed");
+        }
+
+        let queue = &mut self.0;
+
         // shrink size to 4 by removing from the back
         while queue.len() > 4 {
             queue.pop_back();
         }
 
-        queue.push_front(now);
+        queue.push_front(time);
 
-        return result;
+        return Ok(());
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{thread::sleep, time::Duration};
+    use std::time::Duration;
 
     struct Result {
         allowed: bool,
@@ -103,19 +118,19 @@ mod tests {
         let mut expected = vec![];
         let ips = vec![
             "127.0.0.1".parse().unwrap(),
-            "192.168.1.1".parse().unwrap(),
-            "172.167.2.3".parse().unwrap(),
-            "97.231.252.215".parse().unwrap(),
-            "248.97.91.167".parse().unwrap(),
-            "188.208.233.47".parse().unwrap(),
-            "104.2.183.179".parse().unwrap(),
-            "72.129.46.120".parse().unwrap(),
-            "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
-            "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
-            "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
-            "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
-            "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
-            "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
+            // "192.168.1.1".parse().unwrap(),
+            // "172.167.2.3".parse().unwrap(),
+            // "97.231.252.215".parse().unwrap(),
+            // "248.97.91.167".parse().unwrap(),
+            // "188.208.233.47".parse().unwrap(),
+            // "104.2.183.179".parse().unwrap(),
+            // "72.129.46.120".parse().unwrap(),
+            // "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
+            // "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
+            // "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
+            // "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
+            // "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
+            // "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
         ips.iter().for_each(|addr| {
@@ -166,11 +181,14 @@ mod tests {
             text: "packet following 2 packet burst",
         });
 
+        let mut time = Instant::now();
+
         for item in expected {
-            sleep(item.wait);
+            time += item.wait;
+
             for ip in ips.iter() {
                 assert_eq!(
-                    ratelimiter.is_new_packet_allowed(&ip),
+                    ratelimiter.try_register_new_packet_at(&ip, time),
                     item.allowed,
                     "test failed for {} on {}. expected: {}, got: {}",
                     ip,

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -100,19 +100,19 @@ mod tests {
         let mut expected = vec![];
         let ips = vec![
             "127.0.0.1".parse().unwrap(),
-            "192.168.1.1".parse().unwrap(),
-            "172.167.2.3".parse().unwrap(),
-            "97.231.252.215".parse().unwrap(),
-            "248.97.91.167".parse().unwrap(),
-            "188.208.233.47".parse().unwrap(),
-            "104.2.183.179".parse().unwrap(),
-            "72.129.46.120".parse().unwrap(),
-            "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
-            "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
-            "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
-            "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
-            "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
-            "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
+            // "192.168.1.1".parse().unwrap(),
+            // "172.167.2.3".parse().unwrap(),
+            // "97.231.252.215".parse().unwrap(),
+            // "248.97.91.167".parse().unwrap(),
+            // "188.208.233.47".parse().unwrap(),
+            // "104.2.183.179".parse().unwrap(),
+            // "72.129.46.120".parse().unwrap(),
+            // "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
+            // "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
+            // "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
+            // "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
+            // "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
+            // "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
         for _ in 0..N_PACKETS_BURSTABLE {
@@ -159,9 +159,16 @@ mod tests {
             text: "packet following 2 packet burst",
         });
 
+        let begin = Instant::now();
+
         for item in expected {
             sleep(item.wait);
             for ip in ips.iter() {
+                println!(
+                    "ip: {}, {} ms",
+                    ip,
+                    Instant::now().duration_since(begin).as_millis()
+                );
                 assert_eq!(
                     ratelimiter.allow(&ip),
                     item.allowed,

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -118,19 +118,19 @@ mod tests {
         let mut expected = vec![];
         let ips = vec![
             "127.0.0.1".parse().unwrap(),
-            // "192.168.1.1".parse().unwrap(),
-            // "172.167.2.3".parse().unwrap(),
-            // "97.231.252.215".parse().unwrap(),
-            // "248.97.91.167".parse().unwrap(),
-            // "188.208.233.47".parse().unwrap(),
-            // "104.2.183.179".parse().unwrap(),
-            // "72.129.46.120".parse().unwrap(),
-            // "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
-            // "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
-            // "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
-            // "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
-            // "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
-            // "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
+            "192.168.1.1".parse().unwrap(),
+            "172.167.2.3".parse().unwrap(),
+            "97.231.252.215".parse().unwrap(),
+            "248.97.91.167".parse().unwrap(),
+            "188.208.233.47".parse().unwrap(),
+            "104.2.183.179".parse().unwrap(),
+            "72.129.46.120".parse().unwrap(),
+            "2001:0db8:0a0b:12f0:0000:0000:0000:0001".parse().unwrap(),
+            "f5c2:818f:c052:655a:9860:b136:6894:25f0".parse().unwrap(),
+            "b2d7:15ab:48a7:b07c:a541:f144:a9fe:54fc".parse().unwrap(),
+            "a47b:786e:1671:a22b:d6f9:4ab0:abc7:c918".parse().unwrap(),
+            "ea1e:d155:7f7a:98fb:2bf5:9483:80f6:5445".parse().unwrap(),
+            "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
         ips.iter().for_each(|addr| {

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -6,8 +6,6 @@ const N_PACKETS_BURSTABLE: usize = 5;
 const PACKETS_PER_SECOND: u32 = 20;
 const MIN_PACKET_DELAY_NS: u32 = 1_000_000_000 / PACKETS_PER_SECOND;
 
-struct RecordedTimes(VecDeque<Instant>);
-
 pub struct RateLimiter {
     table: spin::RwLock<HashMap<IpAddr, spin::Mutex<RecordedTimes>>>,
 }
@@ -19,40 +17,45 @@ impl RateLimiter {
         }
     }
 
-    pub fn allow(&mut self, addr: &IpAddr) -> bool {
+    /// Check if a packet is allowed. If 'ip_address' is not already registered, register it.
+    pub fn is_new_packet_allowed(&mut self, ip_address: &IpAddr) -> bool {
         // check for existing entry (only requires read lock)
-        if !self.contains(addr) {
+        if !self.is_registered(ip_address) {
             // add new entry (write lock)
-            self.insert(addr);
+            self.register(ip_address);
         }
 
         let table = self.table.read();
 
         let mut recorded_times = table
-            .get(addr)
+            .get(ip_address)
             .expect("Table should contain address")
             .lock();
 
         recorded_times.is_allowed()
     }
 
-    fn contains(&self, addr: &IpAddr) -> bool {
-        self.table.read().contains_key(addr)
+    /// Checks if 'ip_address' is already registered into the RateLimiter.
+    pub fn is_registered(&self, ip_address: &IpAddr) -> bool {
+        self.table.read().contains_key(ip_address)
     }
 
-    fn insert(&mut self, addr: &IpAddr) {
+    /// Register 'ip_address' into the RateLimiter.
+    pub fn register(&mut self, ip_address: &IpAddr) {
         self.table
             .write()
-            .insert(*addr, spin::Mutex::new(RecordedTimes::new()));
+            .insert(*ip_address, spin::Mutex::new(RecordedTimes::new()));
     }
 }
+
+struct RecordedTimes(VecDeque<Instant>);
 
 impl RecordedTimes {
     fn new() -> Self {
         Self(VecDeque::new())
     }
 
-    pub fn is_allowed(&mut self) -> bool {
+    fn is_allowed(&mut self) -> bool {
         let mut result = false;
 
         let now = Instant::now();
@@ -115,6 +118,10 @@ mod tests {
             "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
+        ips.iter().for_each(|addr| {
+            ratelimiter.register(addr);
+        });
+
         for _ in 0..N_PACKETS_BURSTABLE {
             expected.push(Result {
                 allowed: true,
@@ -163,7 +170,7 @@ mod tests {
             sleep(item.wait);
             for ip in ips.iter() {
                 assert_eq!(
-                    ratelimiter.allow(&ip),
+                    ratelimiter.is_new_packet_allowed(&ip),
                     item.allowed,
                     "test failed for {} on {}. expected: {}, got: {}",
                     ip,

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -1,117 +1,92 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
-use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
-const PACKETS_PER_SECOND: u64 = 20;
-const PACKETS_BURSTABLE: u64 = 5;
-const PACKET_COST: u64 = 1_000_000_000 / PACKETS_PER_SECOND;
-const MAX_TOKENS: u64 = PACKET_COST * PACKETS_BURSTABLE;
+const N_PACKETS_BURSTABLE: usize = 5;
+const PACKETS_PER_SECOND: u32 = 20;
+const MIN_PACKET_DELAY_NS: u32 = 1_000_000_000 / PACKETS_PER_SECOND;
 
-const GC_INTERVAL: Duration = Duration::from_secs(1);
+struct RecordedTimes(VecDeque<Instant>);
 
-struct Entry {
-    pub last_time: Instant,
-    pub tokens: u64,
-}
-
-pub struct RateLimiter(Arc<RateLimiterInner>);
-
-struct RateLimiterInner {
-    gc_running: AtomicBool,
-    gc_dropped: (Mutex<bool>, Condvar),
-    table: spin::RwLock<HashMap<IpAddr, spin::Mutex<Entry>>>,
-}
-
-impl Drop for RateLimiter {
-    fn drop(&mut self) {
-        // wake up & terminate any lingering GC thread
-        let &(ref lock, ref cvar) = &self.0.gc_dropped;
-        let mut dropped = lock.lock().unwrap();
-        *dropped = true;
-        cvar.notify_all();
-    }
+pub struct RateLimiter {
+    table: spin::RwLock<HashMap<IpAddr, spin::Mutex<RecordedTimes>>>,
 }
 
 impl RateLimiter {
     pub fn new() -> Self {
-        #[allow(clippy::mutex_atomic)]
-        RateLimiter(Arc::new(RateLimiterInner {
-            gc_dropped: (Mutex::new(false), Condvar::new()),
-            gc_running: AtomicBool::from(false),
+        RateLimiter {
             table: spin::RwLock::new(HashMap::new()),
-        }))
+        }
     }
 
-    pub fn allow(&self, addr: &IpAddr) -> bool {
-        // check if allowed
-        let allowed = {
-            // check for existing entry (only requires read lock)
-            if let Some(entry) = self.0.table.read().get(addr) {
-                // update existing entry
-                let mut entry = entry.lock();
-
-                // add tokens earned since last time
-                entry.tokens = MAX_TOKENS
-                    .min(entry.tokens + u64::from(entry.last_time.elapsed().subsec_nanos()));
-                entry.last_time = Instant::now();
-
-                // subtract cost of packet
-                if entry.tokens > PACKET_COST {
-                    entry.tokens -= PACKET_COST;
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-
+    pub fn allow(&mut self, addr: &IpAddr) -> bool {
+        // check for existing entry (only requires read lock)
+        if !self.contains(addr) {
             // add new entry (write lock)
-            self.0.table.write().insert(
-                *addr,
-                spin::Mutex::new(Entry {
-                    last_time: Instant::now(),
-                    tokens: MAX_TOKENS - PACKET_COST,
-                }),
-            );
-            true
-        };
-
-        // check that GC thread is scheduled
-        if !self.0.gc_running.swap(true, Ordering::Relaxed) {
-            let limiter = self.0.clone();
-            thread::spawn(move || {
-                let &(ref lock, ref cvar) = &limiter.gc_dropped;
-                let mut dropped = lock.lock().unwrap();
-                while !*dropped {
-                    // garbage collect
-                    {
-                        let mut tw = limiter.table.write();
-                        tw.retain(|_, ref mut entry| {
-                            entry.lock().last_time.elapsed() <= GC_INTERVAL
-                        });
-                        if tw.len() == 0 {
-                            limiter.gc_running.store(false, Ordering::Relaxed);
-                            return;
-                        }
-                    }
-
-                    // wait until stopped or new GC (~1 every sec)
-                    let res = cvar.wait_timeout(dropped, GC_INTERVAL).unwrap();
-                    dropped = res.0;
-                }
-            });
+            self.insert(addr);
         }
 
-        allowed
+        let table = self.table.read();
+
+        let mut recorded_times = table
+            .get(addr)
+            .expect("Table should contain address")
+            .lock();
+
+        recorded_times.is_allowed()
+    }
+
+    fn contains(&self, addr: &IpAddr) -> bool {
+        self.table.read().contains_key(addr)
+    }
+
+    fn insert(&mut self, addr: &IpAddr) {
+        self.table
+            .write()
+            .insert(*addr, spin::Mutex::new(RecordedTimes::new()));
+    }
+}
+
+impl RecordedTimes {
+    fn new() -> Self {
+        Self(VecDeque::new())
+    }
+
+    pub fn is_allowed(&mut self) -> bool {
+        let mut result = false;
+
+        let now = Instant::now();
+
+        let queue = &mut self.0;
+
+        for i in 0..N_PACKETS_BURSTABLE {
+            let allowed_for_i = queue.get(i).map_or(true, |then| {
+                now.duration_since(*then).as_nanos()
+                    >= MIN_PACKET_DELAY_NS as u128 * (i + 1) as u128
+            });
+
+            if allowed_for_i {
+                result = true;
+
+                break;
+            }
+        }
+
+        // shrink size to 4 by removing from the back
+        while queue.len() > 4 {
+            queue.pop_back();
+        }
+
+        queue.push_front(now);
+
+        return result;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std;
+    use std::{thread::sleep, time::Duration};
 
     struct Result {
         allowed: bool,
@@ -121,7 +96,7 @@ mod tests {
 
     #[test]
     fn test_ratelimiter() {
-        let ratelimiter = RateLimiter::new();
+        let mut ratelimiter = RateLimiter::new();
         let mut expected = vec![];
         let ips = vec![
             "127.0.0.1".parse().unwrap(),
@@ -140,7 +115,7 @@ mod tests {
             "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
-        for _ in 0..PACKETS_BURSTABLE {
+        for _ in 0..N_PACKETS_BURSTABLE {
             expected.push(Result {
                 allowed: true,
                 wait: Duration::new(0, 0),
@@ -156,7 +131,7 @@ mod tests {
 
         expected.push(Result {
             allowed: true,
-            wait: Duration::new(0, PACKET_COST as u32),
+            wait: Duration::new(0, MIN_PACKET_DELAY_NS),
             text: "filling tokens for single packet",
         });
 
@@ -168,7 +143,7 @@ mod tests {
 
         expected.push(Result {
             allowed: true,
-            wait: Duration::new(0, 2 * PACKET_COST as u32),
+            wait: Duration::new(0, 2 * MIN_PACKET_DELAY_NS),
             text: "filling tokens for 2 * packet burst",
         });
 
@@ -185,14 +160,17 @@ mod tests {
         });
 
         for item in expected {
-            std::thread::sleep(item.wait);
+            sleep(item.wait);
             for ip in ips.iter() {
-                if ratelimiter.allow(&ip) != item.allowed {
-                    panic!(
-                        "test failed for {} on {}. expected: {}, got: {}",
-                        ip, item.text, item.allowed, !item.allowed
-                    )
-                }
+                assert_eq!(
+                    ratelimiter.allow(&ip),
+                    item.allowed,
+                    "test failed for {} on {}. expected: {}, got: {}",
+                    ip,
+                    item.text,
+                    item.allowed,
+                    !item.allowed
+                )
             }
         }
     }

--- a/src/wireguard/handshake/ratelimiter.rs
+++ b/src/wireguard/handshake/ratelimiter.rs
@@ -1,103 +1,84 @@
-use std::collections::{HashMap, VecDeque};
+use std::cmp;
 use std::net::IpAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-const N_PACKETS_BURSTABLE: usize = 5;
-const PACKETS_PER_SECOND: u32 = 20;
-const MIN_PACKET_DELAY_NS: u32 = 1_000_000_000 / PACKETS_PER_SECOND;
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+
+const PACKETS_PER_SECOND: u64 = 20;
+const N_PACKETS_BURSTABLE: u64 = 5;
+const MIN_PACKET_DELAY: Duration = Duration::from_millis(1000 / PACKETS_PER_SECOND);
 
 pub struct RateLimiter {
-    table: spin::RwLock<HashMap<IpAddr, spin::Mutex<RecordedTimes>>>,
+    table: DashMap<IpAddr, Bucket>,
 }
 
 impl RateLimiter {
     /// Create an empty RateLimiter object.
     pub fn new() -> Self {
         RateLimiter {
-            table: spin::RwLock::new(HashMap::new()),
+            table: DashMap::default(),
         }
     }
 
-    /// Check if a packet is allowed at this moment.
-    ///
-    /// If 'ip_address' is not already registered, register it.
-    pub fn try_register_new_packet(&mut self, ip_address: &IpAddr) -> bool {
-        self.try_register_new_packet_at(ip_address, Instant::now())
+    /// Check if a packet from the given IP address
+    /// is allowed through the rate limiter at the given time.
+    pub fn check(&self, addr: &IpAddr) -> bool {
+        self.check_at(addr, Instant::now())
     }
 
-    /// Check if 'ip_address' is already registered into the RateLimiter.
-    pub fn is_registered(&self, ip_address: &IpAddr) -> bool {
-        self.table.read().contains_key(ip_address)
-    }
-
-    /// Register 'ip_address' into the RateLimiter.
-    pub fn register(&mut self, ip_address: &IpAddr) {
-        self.table
-            .write()
-            .insert(*ip_address, spin::Mutex::new(RecordedTimes::new()));
-    }
-
-    fn try_register_new_packet_at(&mut self, ip_address: &IpAddr, time: Instant) -> bool {
-        // check for existing entry (only requires read lock)
-        if !self.is_registered(ip_address) {
-            // add new entry (write lock)
-            self.register(ip_address);
+    fn check_at(&self, addr: &IpAddr, time: Instant) -> bool {
+        match self.table.entry(*addr) {
+            Entry::Occupied(mut entry) => entry.get_mut().check(time),
+            Entry::Vacant(entry) => {
+                entry.insert(Bucket::new(time));
+                true
+            }
         }
-
-        let table = self.table.read();
-
-        let mut recorded_times = table
-            .get(ip_address)
-            .expect("Table should contain address")
-            .lock();
-
-        recorded_times.record(time).is_ok()
     }
 }
 
-struct RecordedTimes(VecDeque<Instant>);
+struct Bucket {
+    last_refill: Instant,
+    tokens: u64,
+}
 
-impl RecordedTimes {
-    fn new() -> Self {
-        Self(VecDeque::new())
+impl Bucket {
+    fn new(time: Instant) -> Self {
+        Bucket {
+            last_refill: time,
+            tokens: N_PACKETS_BURSTABLE - 1,
+        }
     }
 
-    fn is_allowed(&self, time: Instant) -> bool {
-        let mut result = false;
-
-        let queue = &self.0;
-
-        for i in 0..N_PACKETS_BURSTABLE {
-            let allowed_for_i = queue.get(i).map_or(true, |then| {
-                time.duration_since(*then).as_nanos()
-                    >= MIN_PACKET_DELAY_NS as u128 * (i + 1) as u128
-            });
-
-            if allowed_for_i {
-                result = true;
-
-                break;
+    fn check(&mut self, time: Instant) -> bool {
+        // Try to take a token:
+        // this has the effect of only refilling the
+        // bucket for every N_PACKETS_BURSTABLE packets
+        match self.tokens.checked_sub(1) {
+            Some(token) => {
+                self.tokens = token;
+                return true;
             }
+            None => (),
         }
 
-        result
-    }
+        // LLVM should optimize this away
+        assert_eq!(self.tokens, 0);
 
-    fn record(&mut self, time: Instant) -> Result<(), &'static str> {
-        if !self.is_allowed(time) {
-            return Err("not allowed");
+        // Try to refill the bucket:
+        let delta = time.duration_since(self.last_refill);
+        let delta = delta.as_millis() as u64;
+        let tokens = delta / (MIN_PACKET_DELAY.as_millis() as u64);
+
+        // Check if there are tokens available after refilling
+        if tokens > 0 {
+            self.tokens = cmp::min(tokens, N_PACKETS_BURSTABLE) - 1;
+            self.last_refill = time;
+            true
+        } else {
+            false
         }
-
-        let queue = &mut self.0;
-
-        // shrink size to 4 by removing from the back
-        while queue.len() > 4 {
-            queue.pop_back();
-        }
-
-        queue.push_front(time);
-
-        return Ok(());
     }
 }
 
@@ -114,8 +95,7 @@ mod tests {
 
     #[test]
     fn test_ratelimiter() {
-        let mut ratelimiter = RateLimiter::new();
-        let mut expected = vec![];
+        let ratelimiter = RateLimiter::new();
         let ips = vec![
             "127.0.0.1".parse().unwrap(),
             "192.168.1.1".parse().unwrap(),
@@ -133,9 +113,7 @@ mod tests {
             "3f0e:54a2:f5b4:cd19:a21d:58e1:3746:84c4".parse().unwrap(),
         ];
 
-        ips.iter().for_each(|addr| {
-            ratelimiter.register(addr);
-        });
+        let mut expected = vec![];
 
         for _ in 0..N_PACKETS_BURSTABLE {
             expected.push(Result {
@@ -153,7 +131,7 @@ mod tests {
 
         expected.push(Result {
             allowed: true,
-            wait: Duration::new(0, MIN_PACKET_DELAY_NS),
+            wait: MIN_PACKET_DELAY,
             text: "filling tokens for single packet",
         });
 
@@ -165,7 +143,7 @@ mod tests {
 
         expected.push(Result {
             allowed: true,
-            wait: Duration::new(0, 2 * MIN_PACKET_DELAY_NS),
+            wait: 2 * MIN_PACKET_DELAY,
             text: "filling tokens for 2 * packet burst",
         });
 
@@ -188,7 +166,7 @@ mod tests {
 
             for ip in ips.iter() {
                 assert_eq!(
-                    ratelimiter.try_register_new_packet_at(&ip, time),
+                    ratelimiter.check_at(&ip, time),
                     item.allowed,
                     "test failed for {} on {}. expected: {}, got: {}",
                     ip,


### PR DESCRIPTION
This PR is both a fix for the test issue and a rewrite of the RateLimiter itself.

The test was fixed by creating a private function in RateLimiter that accepts an arbitrary Instant as parameter. This makes it possible to test using pre-calculated durations instead of calling sleep() and now().

The RateLimiter re-write:

- The allow calculation was replaced by a FIFO queue recording the past N timestamps (where N is the allowed burst length), and calculating windowed average delays of 0..N size on this. If any of the calculated delays are acceptable, then we accept the packet.
- A new interface function was added that allow us to register an IP address up front, so that runtime write locking can be reduced if the IP addresses are known beforehand