### PR TITLE
Fix Pure Wireguard Test

### DIFF
--- a/wireguard-rs/src/wireguard/router/peer.rs
+++ b/wireguard-rs/src/wireguard/router/peer.rs
@@ -15,7 +15,7 @@ use super::worker::JobUnion;
 
 use core::mem;
 use core::ops::Deref;
-use core::sync::atomic::AtomicBool;
+use core::sync::atomic;
 
 use alloc::sync::Arc;
 
@@ -131,7 +131,7 @@ impl EncryptionState {
 impl<E: Endpoint, C: Callbacks, T: tun::Writer, B: udp::Writer<E>> DecryptionState<E, C, T, B> {
     fn new(peer: Peer<E, C, T, B>, keypair: &Arc<KeyPair>) -> DecryptionState<E, C, T, B> {
         DecryptionState {
-            confirmed: AtomicBool::new(keypair.initiator),
+            confirmed: atomic::AtomicBool::new(keypair.initiator),
             keypair: keypair.clone(),
             protector: spin::Mutex::new(AntiReplay::new()),
             peer,
@@ -273,6 +273,10 @@ impl<E: Endpoint, C: Callbacks, T: tun::Writer, B: udp::Writer<E>> Peer<E, C, T,
                         let job =
                             SendJob::new(msg, state.nonce, state.keypair.clone(), self.clone());
                         if self.outbound.push(job.clone()) {
+                            // Ensure the queue push is visible to all threads before
+                            // sending the job to workers. This prevents a race where
+                            // a worker processes the job before it's in the per-peer queue.
+                            atomic::fence(atomic::Ordering::SeqCst);
                             state.nonce += 1;
                             (Some(job), false)
                         } else {

--- a/wireguard-rs/src/wireguard/tests.rs
+++ b/wireguard-rs/src/wireguard/tests.rs
@@ -12,6 +12,15 @@ use x25519_dalek::{PublicKey, StaticSecret};
 use pnet::packet::ipv4::MutableIpv4Packet;
 use pnet::packet::ipv6::MutableIpv6Packet;
 
+// MTU (Maximum Transmission Unit) for test interfaces
+const TEST_MTU: usize = 1500;
+
+// Maximum packet size for testing, accounting for MTU (1500) minus IP header (~20 bytes)
+const MAX_TEST_PACKET_SIZE: u32 = 1400;
+
+// Number of packets to send in each direction for the pure WireGuard test.
+const NUM_TEST_PACKETS: usize = 1000;
+
 pub fn make_packet(size: usize, src: IpAddr, dst: IpAddr, id: u64) -> Vec<u8> {
     // expand pseudo random payload
     let mut rng: _ = ChaCha8Rng::seed_from_u64(id);
@@ -59,15 +68,12 @@ fn init() {
     let _ = env_logger::builder().is_test(true).try_init();
 }
 
-/* Create and configure
- * two matching pure (no side-effects) instances of WireGuard.
- *
- * Test:
- *
- * - Handshaking completes successfully
- * - All packets up to MTU are delivered
- * - All packets are delivered in-order
- */
+// Create and configure two matching pure (no side-effects) instances of WireGuard.
+//
+// Test:
+// - Handshaking completes successfully
+// - All packets up to MTU are delivered
+// - All packets are delivered in-order
 #[test]
 fn test_pure_wireguard() {
     init();
@@ -80,7 +86,7 @@ fn test_pure_wireguard() {
     thread::spawn(move || {
         tun_worker(&wireguard_device, tun_reader1);
     });
-    wg1.up(1500);
+    wg1.up(TEST_MTU);
 
     let (fake2, tun_reader2, tun_writer2, _) = dummy::TunTest::create(true);
     let wg2: WireGuard<dummy::TunTest, dummy::PairBind> = WireGuard::new(tun_writer2);
@@ -88,7 +94,7 @@ fn test_pure_wireguard() {
     thread::spawn(move || {
         tun_worker(&wireguard_device, tun_reader2);
     });
-    wg2.up(1500);
+    wg2.up(TEST_MTU);
 
     // create pair bind to connect the interfaces "over the internet"
 
@@ -142,31 +148,30 @@ fn test_pure_wireguard() {
         peer2.set_endpoint(dummy::UnitEndpoint::new());
     }
 
-    let num_packets = 20;
-
     // send IP packets (causing a new handshake)
 
     {
-        let mut packets: Vec<Vec<u8>> = Vec::with_capacity(num_packets);
+        let mut packets: Vec<Vec<u8>> = Vec::with_capacity(NUM_TEST_PACKETS);
+        let mut rng = ChaCha8Rng::seed_from_u64(12345); // Fixed seed for reproducibility
 
-        for id in 0..num_packets {
+        for id in 0..NUM_TEST_PACKETS {
+            // Random size between 0 and MAX_TEST_PACKET_SIZE to stay well under MTU
+            let size = (rng.next_u32() % MAX_TEST_PACKET_SIZE) as usize;
             packets.push(make_packet(
-                50 * id as usize,                // size
+                size,
                 "192.168.1.20".parse().unwrap(), // src
                 "192.168.2.10".parse().unwrap(), // dst
-                id as u64,                       // prng seed
+                id as u64,                       // prng seed for payload
             ));
         }
 
         let mut backup = packets.clone();
 
         while let Some(p) = packets.pop() {
-            println!("send");
             fake1.write(p);
         }
 
         while let Some(p) = backup.pop() {
-            println!("read");
             assert_eq!(
                 hex::encode(fake2.read()),
                 hex::encode(p),
@@ -178,14 +183,17 @@ fn test_pure_wireguard() {
     // send IP packets (other direction)
 
     {
-        let mut packets: Vec<Vec<u8>> = Vec::with_capacity(num_packets);
+        let mut packets: Vec<Vec<u8>> = Vec::with_capacity(NUM_TEST_PACKETS);
+        let mut rng = ChaCha8Rng::seed_from_u64(54321); // Different seed from first direction
 
-        for id in 0..num_packets {
+        for id in 0..NUM_TEST_PACKETS {
+            // Random size between 0 and MAX_TEST_PACKET_SIZE to stay well under MTU
+            let size = (rng.next_u32() % MAX_TEST_PACKET_SIZE) as usize;
             packets.push(make_packet(
-                50 + 50 * id as usize,           // size
+                size,
                 "192.168.2.10".parse().unwrap(), // src
                 "192.168.1.20".parse().unwrap(), // dst
-                (id + 100) as u64,               // prng seed
+                (id + 100) as u64, // prng seed for payload (offset to differ from first direction)
             ));
         }
 


### PR DESCRIPTION
I think I addressed the issue that caused the pure_wireguard test to fail: it subtle.


In `peer.rs` we have this code:

```rust
pub(super) fn send(&self, msg: Vec<u8>, stage: bool) {
    // check if key available
    let (job, need_key) = {
        let mut enc_key = self.enc_key.lock();
        match enc_key.as_mut() {
            None => {
                log::debug!("no key encryption key available");
                if stage {
                    self.staged_packets.lock().push_back(msg);
                };
                (None, true)
            }
            Some(state) => {
                // avoid integer overflow in nonce
                if state.nonce >= REJECT_AFTER_MESSAGES - 1 {
                    log::debug!("encryption key expired");
                    *enc_key = None;
                    if stage {
                        self.staged_packets.lock().push_back(msg);
                    }
                    (None, true)
                } else {
                    log::debug!("encryption state available, nonce = {}", state.nonce);
                    let job =
                        SendJob::new(msg, state.nonce, state.keypair.clone(), self.clone());
                    if self.outbound.push(job.clone()) {
                        state.nonce += 1;
                        (Some(job), false)
                    } else {
                        (None, false)
                    }
                }
            }
        }
    };

    if need_key {
        log::debug!("request new key");
        debug_assert!(job.is_none());
        C::need_key(&self.opaque);
    };

    if let Some(job) = job {
        log::debug!("schedule outbound job");
        self.device.work.send(JobUnion::Outbound(job))
    }
}
```

The problem is that in multi threaded systems, memory consistency is, not trivial:
Writes to memory from one thread might not become immediately visible to other threads, due to caching.

The concrete issue with the code above is that:

1. Thread 1: does `self.outbound.push(job.clone())`
2. Thread 1: then does `self.device.work.send(JobUnion::Outbound(job))`
3. Thread 2: consumes the job from the parallel queue `self.device.work`
4. Thread 2: checks to see if the packet can be sent, but, the effect of `self.outbound.push(job.clone())` is not yet visible to Thread 2 when it checks if it can "consume" the packet.

The solution this PR introduces is adding a [fence](https://doc.rust-lang.org/std/sync/atomic/fn.fence.html) after `self.outbound.push(job.clone())` which ensures that the to all threads, `self.outbound.push(job.clone())` happens before `self.device.work.send(JobUnion::Outbound(job))`.