### PR TITLE
Restore release CI testing

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 build:
-    cargo build
+    cargo build --release
 
 test:
     cargo test --verbose
@@ -19,9 +19,9 @@ check-build:
 integration: build
     #!/usr/bin/env bash
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        cd docker && ./run-tests-macos.sh ../target/debug/wireguard-rs
+        cd docker && ./run-tests-macos.sh ../target/release/wireguard-rs
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        cd docker && ./run-tests-linux.sh ../target/debug/wireguard-rs
+        cd docker && ./run-tests-linux.sh ../target/release/wireguard-rs
     else
         echo "Unsupported OS: $OSTYPE"
         exit 1


### PR DESCRIPTION
In Rust 1.91, running CI with the release version of wireguard fails on ubuntu. I've not been able to reproduce this issue locally. Therefore, I've set the CI to run in debug mode, to see if the error triggers any assertions, but in debug mode it didn't happen at all.

I decided to merge it into develop, so that development can continue until we are able to find the issue with the release version. At the same time, I created this PR where we can test if it works yet, also any fix or debug attempts can go here.