### PR TITLE
Remove atomics from timers

### DIFF
--- a/wireguard-rs/src/wireguard/peer.rs
+++ b/wireguard-rs/src/wireguard/peer.rs
@@ -106,7 +106,7 @@ impl<T: Tun, B: UDP> PeerInner<T, B> {
 
     /* should be called after an authenticated data packet is received */
     pub fn timers_data_received(&self) {
-        self.timers().queue_another_keepalive();
+        self.timers_mut().queue_another_keepalive();
     }
 
     /* Should be called after any type of authenticated packet is sent, whether:
@@ -140,7 +140,7 @@ impl<T: Tun, B: UDP> PeerInner<T, B> {
      */
     pub fn timers_handshake_complete(&self) {
         log::trace!("timers_handshake_complete");
-        let timers_update_result = self.timers().stop_retransmit_handshake_timer();
+        let timers_update_result = self.timers_mut().stop_retransmit_handshake_timer();
         if timers_update_result.is_some() {
             *self.walltime_last_handshake.lock() = Some(SystemTime::now());
         }
@@ -183,7 +183,7 @@ impl<T: Tun, B: UDP> PeerInner<T, B> {
 
     pub fn packet_send_queued_handshake_initiation(&self, is_retry: bool) {
         if !is_retry {
-            self.timers().reset_handshake_attempts();
+            self.timers_mut().reset_handshake_attempts();
         }
         self.packet_send_handshake_initiation();
     }
@@ -247,7 +247,7 @@ impl<T: Tun, B: UDP> Callbacks for PeerInner<T, B> {
             Instant::now() - keypair.birth > REJECT_AFTER_TIME - KEEPALIVE_TIMEOUT - REKEY_TIMEOUT
         }
 
-        if keep_key_fresh(keypair) && peer.timers().register_lastminute_handshake_sent() {
+        if keep_key_fresh(keypair) && peer.timers_mut().register_lastminute_handshake_sent() {
             peer.packet_send_queued_handshake_initiation(false);
         }
     }

--- a/wireguard-rs/src/wireguard/timers/callbacks.rs
+++ b/wireguard-rs/src/wireguard/timers/callbacks.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use log::debug;
@@ -30,12 +29,12 @@ fn call_with_peer_and_timers<F, T: Tun, B: UDP>(
     public_key_of_peer: &PublicKey,
     callback: F,
 ) where
-    F: Fn(&Peer<T, B, B::Endpoint, T::Writer, B::Writer>, &Timers),
+    F: Fn(&Peer<T, B, B::Endpoint, T::Writer, B::Writer>, &mut Timers),
 {
     call_with_peer(wireguard_device, public_key_of_peer, |peer| {
-        let timers = peer.timers();
+        let mut timers = peer.timers_mut();
         if timers.enabled {
-            callback(peer, &timers)
+            callback(peer, &mut timers)
         }
     })
 }
@@ -47,7 +46,10 @@ impl Timers {
     ) {
         call_with_peer_and_timers(wireguard_device, public_key_of_peer, |peer, timers| {
             // check if handshake attempts remaining
-            let attempts = timers.handshake_attempts.fetch_add(1, Ordering::SeqCst);
+            let attempts = {
+                timers.handshake_attempts += 1;
+                timers.handshake_attempts
+            };
             if attempts > MAX_TIMER_HANDSHAKES {
                 debug!(
                     "Handshake for peer {} did not complete after {} attempts, giving up",

--- a/wireguard-rs/src/wireguard/timers/mod.rs
+++ b/wireguard-rs/src/wireguard/timers/mod.rs
@@ -1,6 +1,5 @@
 mod callbacks;
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use hjul::Timer;
@@ -16,9 +15,9 @@ pub struct Timers {
     enabled: bool,
     keepalive_interval: u64,
 
-    handshake_attempts: AtomicUsize,
-    sent_lastminute_handshake: AtomicBool,
-    need_another_keepalive: AtomicBool,
+    handshake_attempts: usize,
+    sent_lastminute_handshake: bool,
+    need_another_keepalive: bool,
 
     retransmit_handshake: Timer,
     send_keepalive: Timer,
@@ -29,8 +28,8 @@ pub struct Timers {
 
 impl Timers {
     #[inline(always)]
-    fn needs_another_keepalive(&self) -> bool {
-        self.need_another_keepalive.swap(false, Ordering::SeqCst)
+    fn needs_another_keepalive(&mut self) -> bool {
+        std::mem::replace(&mut self.need_another_keepalive, false)
     }
 
     pub fn new<T: Tun, B: UDP>(
@@ -51,9 +50,9 @@ impl Timers {
         Timers {
             enabled: timers_started,
             keepalive_interval: 0, // disabled
-            need_another_keepalive: AtomicBool::new(false),
-            sent_lastminute_handshake: AtomicBool::new(false),
-            handshake_attempts: AtomicUsize::new(0),
+            need_another_keepalive: false,
+            sent_lastminute_handshake: false,
+            handshake_attempts: 0,
             retransmit_handshake: spawn_timer(Self::retransmit_handshake),
             send_keepalive: spawn_timer(Self::send_keepalive),
             new_handshake: spawn_timer(Self::new_handshake),
@@ -94,10 +93,9 @@ impl Timers {
         self.new_handshake.stop();
 
         // reset all timer state
-        self.handshake_attempts.store(0, Ordering::SeqCst);
-        self.sent_lastminute_handshake
-            .store(false, Ordering::SeqCst);
-        self.need_another_keepalive.store(false, Ordering::SeqCst);
+        self.handshake_attempts = 0;
+        self.sent_lastminute_handshake = false;
+        self.need_another_keepalive = false;
     }
 
     pub fn start_new_handshake_timer(&self) {
@@ -106,9 +104,9 @@ impl Timers {
         }
     }
 
-    pub fn queue_another_keepalive(&self) {
+    pub fn queue_another_keepalive(&mut self) {
         if self.enabled && !self.send_keepalive.start(KEEPALIVE_TIMEOUT) {
-            self.need_another_keepalive.store(true, Ordering::SeqCst)
+            self.need_another_keepalive = true
         }
     }
 
@@ -132,12 +130,11 @@ impl Timers {
     }
 
     /// Return Some(()) if timers are enabled, None otherwise
-    pub fn stop_retransmit_handshake_timer(&self) -> Option<()> {
+    pub fn stop_retransmit_handshake_timer(&mut self) -> Option<()> {
         if self.enabled {
             self.retransmit_handshake.stop();
-            self.handshake_attempts.store(0, Ordering::SeqCst);
-            self.sent_lastminute_handshake
-                .store(false, Ordering::SeqCst);
+            self.handshake_attempts = 0;
+            self.sent_lastminute_handshake = false;
 
             return Some(());
         }
@@ -171,12 +168,12 @@ impl Timers {
         }
     }
 
-    pub fn reset_handshake_attempts(&self) {
-        self.handshake_attempts.store(0, Ordering::SeqCst);
+    pub fn reset_handshake_attempts(&mut self) {
+        self.handshake_attempts = 0;
     }
 
     /// Return true if the event hasn't been registered before this call, otherwise false
-    pub fn register_lastminute_handshake_sent(&self) -> bool {
-        !self.sent_lastminute_handshake.swap(true, Ordering::Acquire)
+    pub fn register_lastminute_handshake_sent(&mut self) -> bool {
+        !std::mem::replace(&mut self.sent_lastminute_handshake, true)
     }
 }


### PR DESCRIPTION
Remove atomic members from Timers.

I'm not sure this is an improvement though, because the code needs Write locking in more places now than before. Using atomics allowed using Read-only locking at certain places.